### PR TITLE
fontView: LayerSetList() doesn’t take TFont as argument since 816748b

### DIFF
--- a/Lib/defconQt/fontView.py
+++ b/Lib/defconQt/fontView.py
@@ -218,7 +218,7 @@ class InspectorWindow(QWidget):
         layerSetGroup = QGroupBox("Layers", self)
         layerSetGroup.setFlat(True)
         layerSetLayout = QGridLayout(self)
-        layerSetLayout.addWidget(LayerSetList(app.currentFont()), 0, 0)
+        layerSetLayout.addWidget(LayerSetList(), 0, 0)
         layerSetGroup.setLayout(layerSetLayout)
 
         mainLayout = QVBoxLayout()


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "trufont/Lib/defconQt/fontView.py", line 1075, in inspector
    app.inspectorWindow = InspectorWindow()
  File "trufont/Lib/defconQt/fontView.py", line 221, in __init__
    layerSetLayout.addWidget(LayerSetList(app.currentFont()), 0, 0)
  File "trufont/Lib/defconQt/layerSetList.py", line 10, in __init__
    super().__init__(parent, *args, **kwargs)
TypeError: QListWidget(QWidget parent=None): argument 1 has unexpected type 'TFont'
```

LayerSetList() instead of LayerSetList(app.currentFont()) because of https://github.com/trufont/trufont/commit/816748b6d6b14b8b9f80fc904dc2654fd3e0f7c1#diff-63b827e0c990e4937144d052e54e794cL8
