### PR TITLE
meta: add custom glyphList support

### DIFF
--- a/Lib/defconQt/__main__.py
+++ b/Lib/defconQt/__main__.py
@@ -1,9 +1,10 @@
-from defconQt.objects.defcon import TFont
 from defconQt import representationFactories
 from defconQt import icons_db  # noqa
 from defconQt.fontView import Application, MainWindow
+from defconQt.objects.defcon import TFont
 import sys
 import os
+from PyQt5.QtCore import QSettings
 from PyQt5.QtGui import QIcon
 
 
@@ -21,6 +22,11 @@ def main():
     app.setOrganizationDomain("trufont.github.io")
     app.setApplicationName("TruFont")
     app.setWindowIcon(QIcon(":/resources/app.png"))
+    settings = QSettings()
+    glyphListPath = settings.value("settings/glyphListPath", type=str)
+    if glyphListPath and os.path.exists(glyphListPath):
+        from defconQt.util import glyphList
+        app.GL2UV = glyphList.parseGlyphList(glyphListPath)
     window = MainWindow(font)
     window.show()
     sys.exit(app.exec_())

--- a/Lib/defconQt/objects/defcon.py
+++ b/Lib/defconQt/objects/defcon.py
@@ -1,6 +1,7 @@
 from defcon import Font, Contour, Glyph, Point
 from defcon.objects.base import BaseObject
-from fontTools.agl import AGL2UV
+from PyQt5.QtWidgets import QApplication
+import fontTools
 
 
 class TFont(Font):
@@ -59,10 +60,15 @@ class TGlyph(Glyph):
     dirty = property(BaseObject._get_dirty, _set_dirty)
 
     def autoUnicodes(self):
+        app = QApplication.instance()
+        if app.GL2UV is not None:
+            GL2UV = app.GL2UV
+        else:
+            GL2UV = fontTools.agl.AGL2UV
         hexes = "ABCDEF0123456789"
         name = self.name
-        if name in AGL2UV:
-            uni = AGL2UV[name]
+        if name in GL2UV:
+            uni = GL2UV[name]
         elif (name.startswith("uni") and len(name) == 7 and
               all(c in hexes for c in name[3:])):
             uni = int(name[3:], 16)

--- a/Lib/defconQt/util/glyphList.py
+++ b/Lib/defconQt/util/glyphList.py
@@ -1,0 +1,21 @@
+import re
+
+_parseGL_RE = re.compile("([A-Za-z_0-9.]+);([0-9A-F]{4})")
+
+
+def parseGlyphList(path):
+    GL2UV = {}
+    with open(path) as file:
+        for line in file:
+            if not line or line[:1] == '#':
+                continue
+            m = _parseGL_RE.match(line)
+            if not m:
+                print("warning: syntax error in glyphlist: %s".format(
+                    repr(line[:20])))
+            glyphName = m.group(1)
+            if glyphName in GL2UV:
+                print("warning: glyphName redefined in glyphList: {}".format(
+                    glyphName))
+            GL2UV[glyphName] = int(m.group(2), 16)
+    return GL2UV


### PR DESCRIPTION
@moyogo What do you think?

This adds support of custom glyph lists in the form `A;0041` as in AGL (not AGLFN which is backwards and has an additional field). 
I was thinking, since glyph names in UFO are unboun, you could very much have ; in a glyph name.