### PR TITLE
Avoid crashing the application in case there's not yet any config file

### DIFF
--- a/Lib/defconQt/__main__.py
+++ b/Lib/defconQt/__main__.py
@@ -23,7 +23,7 @@ def main():
     app.setApplicationName("TruFont")
     app.setWindowIcon(QIcon(":/resources/app.png"))
     settings = QSettings()
-    glyphListPath = settings.value("settings/glyphListPath", type=str)
+    glyphListPath = settings.value("settings/glyphListPath", "", type=str)
     if glyphListPath and os.path.exists(glyphListPath):
         from defconQt.util import glyphList
         try:


### PR DESCRIPTION
Avoid crashing the application in case there's not yet any config file, by passing a default value to the glyphList entry in the TruFont settings.