### PR TITLE
Integrate py2app

### DIFF
--- a/Lib/build.sh
+++ b/Lib/build.sh
@@ -1,1 +1,5 @@
-pyinstaller --onefile TruFont.spec
+if [ $(uname) == 'Darwin' ]; then
+	python setup.py py2app
+else
+	pyinstaller --onefile TruFont.spec
+fi

--- a/qt.conf
+++ b/qt.conf
@@ -1,0 +1,2 @@
+[Paths]
+Plugins = PlugIns


### PR DESCRIPTION
## Requesting assistance

1. The glyph view button borders get messed up when building with py2app and I can't figure out why. Can someone take a look and help me out?

    ![screen shot 2016-01-25 at 5 26 54 pm](https://cloud.githubusercontent.com/assets/342964/12655151/98b61a42-c5c5-11e5-9df8-f2931cb10392.png)

2. The resulting application bundle is twice as large as the one built by PyInstaller. I'm a little stumped here too.

Purpose:
--------

This change switches the packaging tool on Mac from PyInstaller to
Py2app in order to take advantage of Py2app's support for ARGV
emulation. This allows us to open files by dragging them onto the
application.

With Adrien's change ac63e80c57b37527f331b209f88d583deeeabcd3, dragging
files onto the application will open files even if the application is
already launched.

To Build:
---------

Run

    $ sh Lib/build.sh

This is the same as:

    $ python setup.py py2app

Only use py2app if we run the setup file on a Mac. We also have some
pre- and post-build instructions that need to be run, and these are only
executed when on a Mac and the `py2app` argument is passed to `setup.py`
(so they don't get mistakenly run on `python setup.py install`).

If the build script is run on a non-Mac platform, PyInstaller will be
used to build the application bundle as before.

Additional Information
----------------------

* setup.py: Uncommented the `sys` import as I needed it to determine the
  current platform and whether we're running `py2app`.
* Globs are used in the Qt framework paths to allow developers/packagers
  to use different versions of Qt5. I did this because I'm running OS X
  10.8 and couldn't get Qt 5.5 to build on my machine, so I'm using
  homebrew/versions/qt52. Homebrew is assumed.
* The `libqsvgicon.dylib` dylib must be added manually or our glyph view
  toolbar icons don't get rendered.
* The `libqcocoa.dylib` library must be added or we get this error when
  trying to start the application:

      This application failed to start because it could not find or load the Qt platform plugin "cocoa".

      Reinstalling the application may fix this problem.
      Abort trap: 6

* We supply a `qt.conf` file to specify the location of the Qt plugins
  directory. This allows us to specify where to find the dylibs we
  manually copied into the application bundle.

Info.plist
----------

The Info.plist file generated for the application bundle has been
extended and modified.

* `NSHighResolutionCapable=YES` was kept
* `LSBackgroundOnly=NO` was removed because not setting it turns it off
  by default
* Include the `CFBundleIdentifier` copied from `TruFont.spec`
* Set `NSHumanReadableCopyright` to empty string. Otherwise by default
  Py2app will insert this key for you whether you like it or not with
  the value "Copyright not specified".
* Add the `CFBundleDocumentTypes` key to declare TruFont as an app
  capable of opening *.ufo files. This allows us to select TruFont as
  the default app to open one or all files of this type using the
  "Open with…" functionality throughout OS X.

Known Issues
------------

* The button borders in the glyph view toolbar are wrong. They're square
  when they should be invisible with gradiented backgrounds. Not sure
  how to correct this.
* This application bundle is about 20 Mb larger than the previous one
  generated by PyInstaller. Not sure what's going on there.

Fixes #90.