### PR TITLE
Translation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 dist/
+src/
 *.egg-info/
 __pycache__/
 *.pyc

--- a/Lib/defconQt/__main__.py
+++ b/Lib/defconQt/__main__.py
@@ -1,8 +1,11 @@
 from defconQt import __version__, representationFactories
 from defconQt import icons_db  # noqa
 from defconQt.fontView import Application
-from PyQt5.QtCore import QCommandLineParser, QSettings
+from PyQt5.QtCore import (
+    QCommandLineParser, QSettings, QTranslator, QLocale,
+    QLibraryInfo)
 from PyQt5.QtGui import QIcon
+from PyQt5.QtWidgets import QApplication
 import os
 import sys
 
@@ -17,13 +20,29 @@ def main():
     app.setApplicationName("TruFont")
     app.setApplicationVersion(__version__)
     app.setWindowIcon(QIcon(":/resources/app.png"))
+
+    # Qt's translation for itself. May not be installed.
+    qtTranslator = QTranslator()
+    qtTranslator.load("qt_" + QLocale.system().name(),
+                      QLibraryInfo.location(QLibraryInfo.TranslationsPath))
+    app.installTranslator(qtTranslator)
+
+    appTranslator = QTranslator()
+    appTranslator.load("trufont_" + QLocale.system().name(),
+                       os.path.dirname(os.path.realpath(__file__)) +
+                       "/resources")
+    app.installTranslator(appTranslator)
+
     app.loadGlyphList()
     # parse options and open fonts
     parser = QCommandLineParser()
-    parser.setApplicationDescription("The TruFont font editor.")
+    parser.setApplicationDescription(QApplication.translate(
+        "Command-line parser", "The TruFont font editor."))
     parser.addHelpOption()
     parser.addVersionOption()
-    parser.addPositionalArgument("files", "The UFO files to open.")
+    parser.addPositionalArgument(QApplication.translate(
+        "Command-line parser", "files"), QApplication.translate(
+        "Command-line parser", "The UFO files to open."))
     parser.process(app)
     args = parser.positionalArguments()
     if not len(args):

--- a/Lib/defconQt/featureTextEditor.py
+++ b/Lib/defconQt/featureTextEditor.py
@@ -17,27 +17,24 @@ class MainEditWindow(QMainWindow):
         self.editor = FeatureTextEditor(self.font.features.text, self)
         self.resize(600, 500)
 
-        fileMenu = QMenu("&File", self)
-        fileMenu.addAction("&Save…", self.save, QKeySequence.Save)
+        fileMenu = QMenu(self.tr("&File"), self)
+        fileMenu.addAction(self.tr("&Save…"), self.save, QKeySequence.Save)
         fileMenu.addSeparator()
-        fileMenu.addAction("&Reload From Disk", self.reload)
-        fileMenu.addAction("E&xit", self.close, QKeySequence.Quit)
+        fileMenu.addAction(self.tr("&Reload From Disk"), self.reload)
+        fileMenu.addAction(self.tr("&Close"), self.close, QKeySequence.Quit)
         self.menuBar().addMenu(fileMenu)
 
         self.setCentralWidget(self.editor)
-        self.setWindowTitle(font=self.font)
+        self.setWindowTitle(self.tr("Font Features - {0} {1}").format(
+            self.font.info.familyName, self.font.info.styleName))
         self.editor.modificationChanged.connect(self.setWindowModified)
 
     def setWindowTitle(self, title="Font Features", font=None):
-        if font is not None:
-            puts = "[*]%s – %s %s" % (
-                title, self.font.info.familyName, self.font.info.styleName)
-        else:
-            puts = "[*]%s" % title
-        super(MainEditWindow, self).setWindowTitle(puts)
+        super(MainEditWindow, self).setWindowTitle("[*]" + title)
 
     def _fontInfoChanged(self, notification):
-        self.setWindowTitle(font=self.font)
+        self.setWindowTitle(self.tr("Font Features - {0} {1}").format(
+            self.font.info.familyName, self.font.info.styleName))
 
     def closeEvent(self, event):
         if self.editor.document().isModified():
@@ -45,12 +42,12 @@ class MainEditWindow(QMainWindow):
             closeDialog = QMessageBox(
                 QMessageBox.Question,
                 name,
-                "Save your changes?",
+                self.tr("Save your changes?"),
                 QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel,
                 self
             )
             closeDialog.setInformativeText(
-                "Your changes will be lost if you don’t save them."
+                self.tr("Your changes will be lost if you don’t save them.")
             )
             closeDialog.setModal(True)
             ret = closeDialog.exec_()

--- a/Lib/defconQt/fontInfo.py
+++ b/Lib/defconQt/fontInfo.py
@@ -38,7 +38,7 @@ class TabDialog(QDialog):
         mainLayout.addWidget(buttonBox)
         self.setLayout(mainLayout)
 
-        self.setWindowTitle("Font Info – %s %s" % (
+        self.setWindowTitle(self.tr("Font Info – {0} {1}").format(
             self.font.info.familyName, self.font.info.styleName))
 
     def accept(self):
@@ -179,23 +179,25 @@ class TabWidget(QWidget):
 class GeneralTab(TabWidget):
 
     def __init__(self, font, parent=None):
-        super().__init__(parent, name="General")
+        super().__init__(parent)
+        self.name = self.tr("General")
+
         mainLayout = QGridLayout(self)
 
-        familyNameLabel = QLabel("Family name:", self)
-        styleNameLabel = QLabel("Style name:", self)
-        designerLabel = QLabel("Designer:", self)
-        designerURLLabel = QLabel("Designer URL:", self)
-        manufacturerLabel = QLabel("Manufacturer:", self)
-        manufacturerURLLabel = QLabel("Manufacturer URL:", self)
-        copyrightLabel = QLabel("Copyright:", self)
-        licenseLabel = QLabel("License:", self)
-        licenseURLLabel = QLabel("License URL:", self)
-        trademarkLabel = QLabel("Trademark:", self)
+        familyNameLabel = QLabel(self.tr("Family name:"), self)
+        styleNameLabel = QLabel(self.tr("Style name:"), self)
+        designerLabel = QLabel(self.tr("Designer:"), self)
+        designerURLLabel = QLabel(self.tr("Designer URL:"), self)
+        manufacturerLabel = QLabel(self.tr("Manufacturer:"), self)
+        manufacturerURLLabel = QLabel(self.tr("Manufacturer URL:"), self)
+        copyrightLabel = QLabel(self.tr("Copyright:"), self)
+        licenseLabel = QLabel(self.tr("License:"), self)
+        licenseURLLabel = QLabel(self.tr("License URL:"), self)
+        trademarkLabel = QLabel(self.tr("Trademark:"), self)
         # TODO: give visual feedback of input data validity using QLineEdit
         # lose focus event
         # http://snorf.net/blog/2014/08/09/using-qvalidator-in-pyqt4-to-validate-user-input/ # noqa
-        versionLabel = QLabel("Version:", self)
+        versionLabel = QLabel(self.tr("Version:"), self)
         versionDotLabel = QLabel(".", self)
         self.loadString(font, "familyName", "familyName")
         self.loadString(font, "styleName", "styleName")
@@ -230,7 +232,7 @@ class GeneralTab(TabWidget):
         mainLayout.addWidget(versionDotLabel, 6, 2)
         mainLayout.addWidget(self.versionMinorEdit, 6, 3)
 
-        dateCreatedLabel = QLabel("Date created:", self)
+        dateCreatedLabel = QLabel(self.tr("Date created:"), self)
         dateTime = QDateTime()
         # dateTime.fromString(font.info.openTypeHeadCreated, "yyyy/MM/dd
         # hh:mm:ss") # XXX: why does this not work?
@@ -284,15 +286,18 @@ class GeneralTab(TabWidget):
 class MetricsTab(TabWidget):
 
     def __init__(self, font, parent=None):
-        super().__init__(parent, name="Metrics")
+        super().__init__(parent)
+        self.name = self.tr("Metrics")
+
         mainLayout = QGridLayout()
 
-        styleMapFamilyLabel = QLabel("Style map family name:", self)
+        styleMapFamilyLabel = QLabel(self.tr("Style map family name:"), self)
         self.styleMapFamilyEdit = QLineEdit(font.info.styleMapFamilyName, self)
 
-        styleMapStyleLabel = QLabel("Style map style name:", self)
+        styleMapStyleLabel = QLabel(self.tr("Style map style name:"), self)
         self.styleMapStyleDrop = QComboBox(self)
-        items = ["None", "Regular", "Italic", "Bold", "Bold Italic"]
+        items = [self.tr("None"), self.tr("Regular"), self.tr("Italic"),
+                 self.tr("Bold"), self.tr("Bold Italic")]
         self.styleMapStyleDrop.insertItems(0, items)
         sn = font.info.styleMapStyleName
         if sn == "regular":
@@ -311,13 +316,13 @@ class MetricsTab(TabWidget):
         mainLayout.addWidget(styleMapStyleLabel, 0, 4)
         mainLayout.addWidget(self.styleMapStyleDrop, 0, 5)
 
-        unitsPerEmLabel = QLabel("Units per em:", self)
-        ascenderLabel = QLabel("Ascender:", self)
-        capHeightLabel = QLabel("Cap height:", self)
-        italicAngleLabel = QLabel("Italic angle:", self)
-        descenderLabel = QLabel("Descender:", self)
-        xHeightLabel = QLabel("x-height:", self)
-        noteLabel = QLabel("Note:", self)
+        unitsPerEmLabel = QLabel(self.tr("Units per em:"), self)
+        ascenderLabel = QLabel(self.tr("Ascender:"), self)
+        capHeightLabel = QLabel(self.tr("Cap height:"), self)
+        italicAngleLabel = QLabel(self.tr("Italic angle:"), self)
+        descenderLabel = QLabel(self.tr("Descender:"), self)
+        xHeightLabel = QLabel(self.tr("x-height:"), self)
+        noteLabel = QLabel(self.tr("Note:"), self)
         # In the UFO specs these are integer or float, and unitsPerEm is
         # non-negative integer or float
         self.loadPositiveIntegerFloat(font, "unitsPerEm", "unitsPerEm")
@@ -376,21 +381,24 @@ class MetricsTab(TabWidget):
 class OpenTypeTab(TabWidget):
 
     def __init__(self, font, parent=None):
-        super().__init__(parent, name="OpenType")
+        super().__init__(parent)
+        self.name = self.tr("OpenType")
 
-        nameGroup = QGroupBox("name table", self)
+        nameGroup = QGroupBox(self.tr("name table"), self)
         # nameGroup.setFlat(True)
         nameLayout = QGridLayout(self)
 
-        preferredFamilyNameLabel = QLabel("Pref. Family Name:", self)
-        preferredSubfamilyNameLabel = QLabel("Pref. Subfamily Name:", self)
-        compatibleFullNameLabel = QLabel("Compatible Full Name:", self)
-        WWSFamilyNameLabel = QLabel("WWS Family Name:", self)
-        WWSSubfamilyNameLabel = QLabel("WWS Subfamily Name:", self)
-        versionLabel = QLabel("Version:", self)
-        uniqueIDLabel = QLabel("Unique ID:", self)
-        descriptionLabel = QLabel("Description:", self)
-        sampleTextLabel = QLabel("Sample text:", self)
+        preferredFamilyNameLabel = QLabel(self.tr("Pref. Family Name:"), self)
+        preferredSubfamilyNameLabel = QLabel(self.tr("Pref. Subfamily Name:"),
+                                             self)
+        compatibleFullNameLabel = QLabel(self.tr("Compatible Full Name:"),
+                                         self)
+        WWSFamilyNameLabel = QLabel(self.tr("WWS Family Name:"), self)
+        WWSSubfamilyNameLabel = QLabel(self.tr("WWS Subfamily Name:"), self)
+        versionLabel = QLabel(self.tr("Version:"), self)
+        uniqueIDLabel = QLabel(self.tr("Unique ID:"), self)
+        descriptionLabel = QLabel(self.tr("Description:"), self)
+        sampleTextLabel = QLabel(self.tr("Sample text:"), self)
         self.loadString(
             font, "openTypeNamePreferredFamilyName", "preferredFamilyName")
         self.loadString(
@@ -431,16 +439,16 @@ class OpenTypeTab(TabWidget):
         nameLayout.addWidget(self.sampleTextEdit, l, 4, 1, 2)
         nameGroup.setLayout(nameLayout)
 
-        hheaGroup = QGroupBox("hhea table", self)
+        hheaGroup = QGroupBox(self.tr("hhea table"), self)
         # hheaGroup.setFlat(True)
         hheaLayout = QGridLayout(self)
 
-        ascenderLabel = QLabel("Ascender:", self)
-        descenderLabel = QLabel("Descender:", self)
-        lineGapLabel = QLabel("LineGap:", self)
-        caretSlopeRiseLabel = QLabel("caretSlopeRise:", self)
-        caretSlopeRunLabel = QLabel("caretSlopeRun:", self)
-        caretOffsetLabel = QLabel("caretOffset:", self)
+        ascenderLabel = QLabel(self.tr("Ascender:"), self)
+        descenderLabel = QLabel(self.tr("Descender:"), self)
+        lineGapLabel = QLabel(self.tr("LineGap:"), self)
+        caretSlopeRiseLabel = QLabel(self.tr("caretSlopeRise:"), self)
+        caretSlopeRunLabel = QLabel(self.tr("caretSlopeRun:"), self)
+        caretOffsetLabel = QLabel(self.tr("caretOffset:"), self)
         self.loadInteger(font, "openTypeHheaAscender", "ascender")
         self.loadInteger(font, "openTypeHheaDescender", "descender")
         self.loadInteger(font, "openTypeHheaLineGap", "lineGap")
@@ -465,16 +473,16 @@ class OpenTypeTab(TabWidget):
         hheaLayout.addWidget(self.caretOffsetEdit, l, 4, 1, 2)
         hheaGroup.setLayout(hheaLayout)
 
-        vheaGroup = QGroupBox("vhea table", self)
+        vheaGroup = QGroupBox(self.tr("vhea table"), self)
         # vheaGroup.setFlat(True)
         vheaLayout = QGridLayout(self)
 
-        vertTypoAscenderLabel = QLabel("vertTypoAscender:", self)
-        vertTypoDescenderLabel = QLabel("vertTypoDescender:", self)
-        vertTypoLineGapLabel = QLabel("vertTypoLineGap:", self)
-        vheaCaretSlopeRiseLabel = QLabel("caretSlopeRise:", self)
-        vheaCaretSlopeRunLabel = QLabel("caretSlopeRun:", self)
-        vheaCaretOffsetLabel = QLabel("caretOffset:", self)
+        vertTypoAscenderLabel = QLabel(self.tr("vertTypoAscender:"), self)
+        vertTypoDescenderLabel = QLabel(self.tr("vertTypoDescender:"), self)
+        vertTypoLineGapLabel = QLabel(self.tr("vertTypoLineGap:"), self)
+        vheaCaretSlopeRiseLabel = QLabel(self.tr("caretSlopeRise:"), self)
+        vheaCaretSlopeRunLabel = QLabel(self.tr("caretSlopeRun:"), self)
+        vheaCaretOffsetLabel = QLabel(self.tr("caretOffset:"), self)
         self.loadInteger(
             font, "openTypeVheaVertTypoAscender", "vertTypoAscender")
         self.loadInteger(
@@ -547,24 +555,27 @@ class OpenTypeTab(TabWidget):
 class OS2Tab(TabWidget):
 
     def __init__(self, font, parent=None):
-        super().__init__(parent, name="OS/2")
+        super().__init__(parent)
+        self.name = self.tr("OS/2")
 
         # OS2Group = QGroupBox("OS/2 table", self)
         # OS2Group.setFlat(True)
         OS2Layout = QGridLayout(self)
 
-        usWidthClassLabel = QLabel("usWidthClass:", self)
+        usWidthClassLabel = QLabel(self.tr("usWidthClass:"), self)
         self.usWidthClassDrop = QComboBox(self)
         items = [
-            "None", "Ultra-condensed", "Extra-condensed", "Condensed",
-            "Semi-Condensed", "Medium (normal)", "Semi-expanded", "Expanded",
-            "Extra-expanded", "Ultra-expanded"]
+            self.tr("None"), self.tr("Ultra-condensed"),
+            self.tr("Extra-condensed"), self.tr("Condensed"),
+            self.tr("Semi-Condensed"), self.tr("Medium (normal)"),
+            self.tr("Semi-expanded"), self.tr("Expanded"),
+            self.tr("Extra-expanded"), self.tr("Ultra-expanded")]
         self.usWidthClassDrop.insertItems(0, items)
         if font.info.openTypeOS2WidthClass is not None:
             self.usWidthClassDrop.setCurrentIndex(
                 font.info.openTypeOS2WidthClass)
 
-        fsSelectionLabel = QLabel("fsSelection:", self)
+        fsSelectionLabel = QLabel(self.tr("fsSelection:"), self)
         fsSelection = font.info.openTypeOS2Selection
         self.fsSelectionList = QListView(self)
         items = [
@@ -585,20 +596,21 @@ class OS2Tab(TabWidget):
             model.setItem(index, item)
         self.fsSelectionList.setModel(model)
 
-        achVendorIDLabel = QLabel("achVendorID:", self)
+        achVendorIDLabel = QLabel(self.tr("achVendorID:"), self)
         self.achVendorIDEdit = QLineEdit(font.info.openTypeOS2VendorID, self)
         self.achVendorIDEdit.setMaxLength(4)
 
-        fsTypeLabel = QLabel("fsType:", self)
+        fsTypeLabel = QLabel(self.tr("fsType:"), self)
         fsType = font.info.openTypeOS2Type
         self.fsTypeDrop = QComboBox(self)
         items = [
-            "No embedding restrictions", "Restricted embedding",
-            "Preview and print embedding allowed",
-            "Editable embedding allowed"]
-        self.allowSubsettingBox = QCheckBox("Allow subsetting", self)
+            self.tr("No embedding restrictions"),
+            self.tr("Restricted embedding"),
+            self.tr("Preview and print embedding allowed"),
+            self.tr("Editable embedding allowed")]
+        self.allowSubsettingBox = QCheckBox(self.tr("Allow subsetting"), self)
         self.allowBitmapEmbeddingBox = QCheckBox(
-            "Allow only bitmap embedding", self)
+            self.tr("Allow only bitmap embedding"), self)
         self.fsTypeDrop.currentIndexChanged[int].connect(
             self._updateFsTypeVisibility)
         self.fsTypeDrop.insertItems(0, items)
@@ -614,22 +626,24 @@ class OS2Tab(TabWidget):
 
         # XXX: ulCodePageRange
 
-        sTypoAscenderLabel = QLabel("sTypoAscender:", self)
-        sTypoDescenderLabel = QLabel("sTypoDescender:", self)
-        sTypoLineGapLabel = QLabel("sTypoLineGap:", self)
-        usWeightClassLabel = QLabel("usWeightClass:", self)
-        usWinAscentLabel = QLabel("usWinAscent:", self)
-        usWinDescentLabel = QLabel("usWinDescent:", self)
-        ySubscriptXSizeLabel = QLabel("ySubscriptXSize:", self)
-        ySubscriptYSizeLabel = QLabel("ySubscriptYSize:", self)
-        ySubscriptXOffsetLabel = QLabel("ySubscriptXOffset:", self)
-        ySubscriptYOffsetLabel = QLabel("ySubscriptYOffset:", self)
-        ySuperscriptXSizeLabel = QLabel("ySuperscriptXSize:", self)
-        ySuperscriptYSizeLabel = QLabel("ySuperscriptYSize:", self)
-        ySuperscriptXOffsetLabel = QLabel("ySuperscriptXOffset:", self)
-        ySuperscriptYOffsetLabel = QLabel("ySuperscriptYOffset:", self)
-        yStrikeoutSizeLabel = QLabel("yStrikeoutSize:", self)
-        yStrikeoutPositionLabel = QLabel("yStrikeoutPosition:", self)
+        sTypoAscenderLabel = QLabel(self.tr("sTypoAscender:"), self)
+        sTypoDescenderLabel = QLabel(self.tr("sTypoDescender:"), self)
+        sTypoLineGapLabel = QLabel(self.tr("sTypoLineGap:"), self)
+        usWeightClassLabel = QLabel(self.tr("usWeightClass:"), self)
+        usWinAscentLabel = QLabel(self.tr("usWinAscent:"), self)
+        usWinDescentLabel = QLabel(self.tr("usWinDescent:"), self)
+        ySubscriptXSizeLabel = QLabel(self.tr("ySubscriptXSize:"), self)
+        ySubscriptYSizeLabel = QLabel(self.tr("ySubscriptYSize:"), self)
+        ySubscriptXOffsetLabel = QLabel(self.tr("ySubscriptXOffset:"), self)
+        ySubscriptYOffsetLabel = QLabel(self.tr("ySubscriptYOffset:"), self)
+        ySuperscriptXSizeLabel = QLabel(self.tr("ySuperscriptXSize:"), self)
+        ySuperscriptYSizeLabel = QLabel(self.tr("ySuperscriptYSize:"), self)
+        ySuperscriptXOffsetLabel = QLabel(self.tr("ySuperscriptXOffset:"),
+                                          self)
+        ySuperscriptYOffsetLabel = QLabel(self.tr("ySuperscriptYOffset:"),
+                                          self)
+        yStrikeoutSizeLabel = QLabel(self.tr("yStrikeoutSize:"), self)
+        yStrikeoutPositionLabel = QLabel(self.tr("yStrikeoutPosition:"), self)
         self.loadPositiveInteger(
             font, "openTypeOS2WeightClass", "usWeightClass")
         self.loadInteger(font, "openTypeOS2TypoAscender", "sTypoAscender")
@@ -788,16 +802,17 @@ class OS2Tab(TabWidget):
 class PostScriptTab(TabWidget):
 
     def __init__(self, font, parent=None):
-        super().__init__(parent, name="PostScript")
+        super().__init__(parent)
+        self.name = self.tr("PostScript")
 
-        namingGroup = QGroupBox("Naming", self)
+        namingGroup = QGroupBox(self.tr("Naming"), self)
         # namingGroup.setFlat(True)
         namingLayout = QGridLayout(self)
 
-        fontNameLabel = QLabel("FontName:", self)
-        fullNameLabel = QLabel("FullName:", self)
-        weightNameLabel = QLabel("WeightName:", self)
-        uniqueIDLabel = QLabel("Unique ID:", self)
+        fontNameLabel = QLabel(self.tr("FontName:"), self)
+        fullNameLabel = QLabel(self.tr("FullName:"), self)
+        weightNameLabel = QLabel(self.tr("WeightName:"), self)
+        uniqueIDLabel = QLabel(self.tr("UniqueID:"), self)
         self.loadString(font, "postscriptFontName", "fontName")
         self.loadString(font, "postscriptFullName", "fullName")
         self.loadString(font, "postscriptWeightName", "weightName")
@@ -815,7 +830,7 @@ class PostScriptTab(TabWidget):
         namingLayout.addWidget(self.uniqueIDEdit, l, 4, 1, 2)
         namingGroup.setLayout(namingLayout)
 
-        hintingGroup = QGroupBox("Hinting", self)
+        hintingGroup = QGroupBox(self.tr("Hints"), self)
         # hintingGroup.setFlat(True)
         hintingLayout = QGridLayout(self)
 
@@ -824,10 +839,10 @@ class PostScriptTab(TabWidget):
         self.loadIntegerFloatList(font, "postscriptFamilyBlues", "familyBlues")
         self.loadIntegerFloatList(
             font, "postscriptFamilyOtherBlues", "familyOtherBlues")
-        blueValuesLabel = QLabel("Blue values:", self)
-        otherBluesLabel = QLabel("Other blues:", self)
-        familyBluesLabel = QLabel("Family blues:", self)
-        familyOtherBluesLabel = QLabel("Family other blues:", self)
+        blueValuesLabel = QLabel(self.tr("BlueValues:"), self)
+        otherBluesLabel = QLabel(self.tr("OtherBlues:"), self)
+        familyBluesLabel = QLabel(self.tr("FamilyBlues:"), self)
+        familyOtherBluesLabel = QLabel(self.tr("FamilyOtherBlues:"), self)
 
         l = 0
         hintingLayout.addWidget(blueValuesLabel, l, 0)
@@ -841,18 +856,18 @@ class PostScriptTab(TabWidget):
         hintingLayout.addWidget(self.familyOtherBluesEdit, l, 4, 1, 2)
         l += 1
 
-        blueFuzzLabel = QLabel("Blue fuzz:", self)
-        stemSnapHLabel = QLabel("StemSnapH:", self)
-        blueScaleLabel = QLabel("Blue scale:", self)
-        stemSnapVLabel = QLabel("StemSnapV:", self)
-        blueShiftLabel = QLabel("Blue shift:", self)
+        blueFuzzLabel = QLabel(self.tr("BlueFuzz:"), self)
+        stemSnapHLabel = QLabel(self.tr("StemSnapH:"), self)
+        blueScaleLabel = QLabel(self.tr("BlueScale:"), self)
+        stemSnapVLabel = QLabel(self.tr("StemSnapV:"), self)
+        blueShiftLabel = QLabel(self.tr("BlueShift:"), self)
         self.loadIntegerFloatList(font, "postscriptStemSnapH", "stemSnapH")
         self.loadIntegerFloatList(font, "postscriptStemSnapV", "stemSnapV")
         self.loadIntegerFloat(font, "postscriptBlueFuzz", "blueFuzz")
         self.loadIntegerFloat(font, "postscriptBlueScale", "blueScale")
         self.loadIntegerFloat(font, "postscriptBlueShift", "blueShift")
 
-        forceBoldLabel = QLabel("Force bold:", self)
+        forceBoldLabel = QLabel(self.tr("ForceBold:"), self)
         self.loadBoolean(font, "postscriptForceBold", "forceBold")
 
         hintingLayout.addWidget(blueFuzzLabel, l, 0)
@@ -871,15 +886,15 @@ class PostScriptTab(TabWidget):
         hintingLayout.addWidget(self.forceBoldBox, l, 4, 1, 2)
         hintingGroup.setLayout(hintingLayout)
 
-        metricsGroup = QGroupBox("Metrics", self)
+        metricsGroup = QGroupBox(self.tr("Metrics"), self)
         # metricsGroup.setFlat(True)
         metricsLayout = QGridLayout(self)
 
-        defaultWidthXLabel = QLabel("DefaultWidthX:", self)
-        underlineThicknessLabel = QLabel("UnderlineThickness:", self)
-        nominalWidthXLabel = QLabel("NominalWidthX:", self)
-        underlinePositionLabel = QLabel("UnderlinePosition:", self)
-        slantAngleLabel = QLabel("SlantAngle:", self)
+        defaultWidthXLabel = QLabel(self.tr("DefaultWidthX:"), self)
+        underlineThicknessLabel = QLabel(self.tr("UnderlineThickness:"), self)
+        nominalWidthXLabel = QLabel(self.tr("NominalWidthX:"), self)
+        underlinePositionLabel = QLabel(self.tr("UnderlinePosition:"), self)
+        slantAngleLabel = QLabel(self.tr("SlantAngle:"), self)
         self.loadIntegerFloat(font, "postscriptDefaultWidthX", "defaultWidthX")
         self.loadIntegerFloat(font, "postscriptNominalWidthX", "nominalWidthX")
         self.loadIntegerFloat(
@@ -888,7 +903,7 @@ class PostScriptTab(TabWidget):
             font, "postscriptUnderlinePosition", "underlinePosition")
         self.loadIntegerFloat(font, "postscriptSlantAngle", "slantAngle")
 
-        isFixedPitchLabel = QLabel("isFixedPitched:", self)
+        isFixedPitchLabel = QLabel(self.tr("isFixedPitched:"), self)
         self.loadBoolean(font, "postscriptIsFixedPitch", "isFixedPitch")
 
         l = 0
@@ -908,20 +923,24 @@ class PostScriptTab(TabWidget):
         metricsLayout.addWidget(self.isFixedPitchBox, l, 4, 1, 2)
         metricsGroup.setLayout(metricsLayout)
 
-        charactersGroup = QGroupBox("Characters", self)
+        charactersGroup = QGroupBox(self.tr("Characters"), self)
         # charactersGroup.setFlat(True)
         charactersLayout = QGridLayout(self)
 
-        defaultCharacterLabel = QLabel("Default character:", self)
+        defaultCharacterLabel = QLabel(self.tr("Default character:"), self)
         self.loadString(font, "postscriptDefaultCharacter", "defaultCharacter")
 
-        windowsCharacterSetLabel = QLabel("Windows character set:", self)
+        windowsCharacterSetLabel = QLabel(self.tr("Windows character set:"),
+                                          self)
         self.windowsCharacterSetDrop = QComboBox(self)
         items = [
-            "None", "ANSI", "Default", "Symbol", "Macintosh", "Shift JIS",
-            "Hangul", "Hangul (Johab)", "GB2312", "Chinese BIG5", "Greek",
-            "Turkish", "Vietnamese", "Hebrew", "Arabic", "Baltic", "Bitstream",
-            "Cyrillic", "Thai", "Eastern European", "OEM"]
+            self.tr("None"), self.tr("ANSI"), self.tr("Default"),
+            self.tr("Symbol"), self.tr("Macintosh"), self.tr("Shift JIS"),
+            self.tr("Hangul"), self.tr("Hangul (Johab)"), self.tr("GB2312"),
+            self.tr("Chinese BIG5"), self.tr("Greek"), self.tr("Turkish"),
+            self.tr("Vietnamese"), self.tr("Hebrew"), self.tr("Arabic"),
+            self.tr("Baltic"), self.tr("Bitstream"), self.tr("Cyrillic"),
+            self.tr("Thai"), self.tr("Eastern European"), self.tr("OEM")]
         self.windowsCharacterSetDrop.insertItems(0, items)
         if font.info.postscriptWindowsCharacterSet is not None:
             self.windowsCharacterSetDrop.setCurrentIndex(

--- a/Lib/defconQt/fontView.py
+++ b/Lib/defconQt/fontView.py
@@ -99,8 +99,9 @@ class Application(QApplication):
             try:
                 glyphList = glyphList.parseGlyphList(glyphListPath)
             except Exception as e:
-                msg = "The glyph list at %s cannot be parsed \
-                       and will be dropped." % glyphListPath
+                msg = self.tr(
+                    "The glyph list at {0} cannot "
+                    "be parsed and will be dropped.").format(glyphListPath)
                 errorReports.showWarningException(e, msg)
                 settings.remove("settings/glyphListPath")
             else:
@@ -197,43 +198,43 @@ class InspectorWindow(QWidget):
 
     def __init__(self):
         super().__init__(flags=Qt.Tool)
-        self.setWindowTitle("Inspector")
+        self.setWindowTitle(self.tr("Inspector"))
         self._blocked = False
         self._glyph = None
 
-        glyphGroup = QGroupBox("Glyph", self)
+        glyphGroup = QGroupBox(self.tr("Glyph"), self)
         glyphGroup.setFlat(True)
         glyphLayout = QGridLayout(self)
         columnOneWidth = self.fontMetrics().width('0') * 7
 
-        nameLabel = QLabel("Name:", self)
+        nameLabel = QLabel(self.tr("Name:"), self)
         self.nameEdit = QLineEdit(self)
         self.nameEdit.editingFinished.connect(self.writeGlyphName)
-        unicodesLabel = QLabel("Unicode:", self)
+        unicodesLabel = QLabel(self.tr("Unicode:"), self)
         self.unicodesEdit = QLineEdit(self)
         self.unicodesEdit.editingFinished.connect(self.writeUnicodes)
         unicodesRegExp = QRegularExpression(
             "(|([a-fA-F0-9]{4,6})( ([a-fA-F0-9]{4,6}))*)")
         unicodesValidator = QRegularExpressionValidator(unicodesRegExp, self)
         self.unicodesEdit.setValidator(unicodesValidator)
-        widthLabel = QLabel("Width:", self)
+        widthLabel = QLabel(self.tr("Width:"), self)
         self.widthEdit = QLineEdit(self)
         self.widthEdit.editingFinished.connect(self.writeWidth)
         self.widthEdit.setMaximumWidth(columnOneWidth)
         self.widthEdit.setValidator(QIntValidator(self))
-        leftSideBearingLabel = QLabel("Left:", self)
+        leftSideBearingLabel = QLabel(self.tr("Left:"), self)
         self.leftSideBearingEdit = QLineEdit(self)
         self.leftSideBearingEdit.editingFinished.connect(
             self.writeLeftSideBearing)
         self.leftSideBearingEdit.setMaximumWidth(columnOneWidth)
         self.leftSideBearingEdit.setValidator(QIntValidator(self))
-        rightSideBearingLabel = QLabel("Right:", self)
+        rightSideBearingLabel = QLabel(self.tr("Right:"), self)
         self.rightSideBearingEdit = QLineEdit(self)
         self.rightSideBearingEdit.editingFinished.connect(
             self.writeRightSideBearing)
         self.rightSideBearingEdit.setMaximumWidth(columnOneWidth)
         self.rightSideBearingEdit.setValidator(QIntValidator(self))
-        markColorLabel = QLabel("Flag:", self)
+        markColorLabel = QLabel(self.tr("Flag:"), self)
         self.markColorWidget = ColorVignette(self)
         self.markColorWidget.colorChanged.connect(
             self.writeMarkColor)
@@ -258,20 +259,20 @@ class InspectorWindow(QWidget):
         glyphLayout.addWidget(self.markColorWidget, l, 1)
         glyphGroup.setLayout(glyphLayout)
 
-        transformGroup = QGroupBox("Transform", self)
+        transformGroup = QGroupBox(self.tr("Transform"), self)
         transformGroup.setFlat(True)
         transformLayout = QGridLayout(self)
 
         # TODO: should this be implemented for partial selection?
         # TODO: phase out fake button
-        symmetryButton = QPushButton("Symmetry", self)
+        symmetryButton = QPushButton(self.tr("Symmetry"), self)
         symmetryButton.setEnabled(False)
-        hSymmetryButton = QPushButton("H", self)
+        hSymmetryButton = QPushButton(self.tr("H"), self)
         hSymmetryButton.clicked.connect(self.hSymmetry)
-        vSymmetryButton = QPushButton("V", self)
+        vSymmetryButton = QPushButton(self.tr("V"), self)
         vSymmetryButton.clicked.connect(self.vSymmetry)
 
-        moveButton = QPushButton("Move", self)
+        moveButton = QPushButton(self.tr("Move"), self)
         moveButton.clicked.connect(self.moveGlyph)
         moveXLabel = QLabel("x:", self)
         self.moveXEdit = QLineEdit("0", self)
@@ -282,7 +283,7 @@ class InspectorWindow(QWidget):
         moveXYBox = QCheckBox("x=y", self)
         moveXYBox.clicked.connect(self.lockMove)
 
-        scaleButton = QPushButton("Scale", self)
+        scaleButton = QPushButton(self.tr("Scale"), self)
         scaleButton.clicked.connect(self.scaleGlyph)
         scaleXLabel = QLabel("x:", self)
         self.scaleXEdit = QLineEdit("100", self)
@@ -313,12 +314,13 @@ class InspectorWindow(QWidget):
         transformLayout.addWidget(scaleXYBox, l, 5)
         transformGroup.setLayout(transformLayout)
 
-        layerSetGroup = QGroupBox("Layers", self)
+        layerSetGroup = QGroupBox(self.tr("Layers"), self)
         layerSetGroup.setFlat(True)
         layerSetLayout = QVBoxLayout(self)
 
         self.layerSetWidget = QTreeWidget(self)
-        self.layerSetWidget.setHeaderLabels(("Layer Name", "Color"))
+        self.layerSetWidget.setHeaderLabels(
+            (self.tr("Layer Name"), self.tr("Color")))
         self.layerSetWidget.setRootIsDecorated(False)
         self.layerSetWidget.setSelectionBehavior(QAbstractItemView.SelectRows)
         # TODO: make this work correctly, top-level items only
@@ -537,13 +539,13 @@ class AddGlyphsDialog(QDialog):
     def __init__(self, currentGlyphs=None, parent=None):
         super(AddGlyphsDialog, self).__init__(parent)
         self.setWindowModality(Qt.WindowModal)
-        self.setWindowTitle("Add Glyphs…")
+        self.setWindowTitle(self.tr("Add Glyphs…"))
         self.currentGlyphs = currentGlyphs
         self.currentGlyphNames = [glyph.name for glyph in currentGlyphs]
 
         layout = QGridLayout(self)
         self.importCharDrop = QComboBox(self)
-        self.importCharDrop.addItem("Import glyphnames…")
+        self.importCharDrop.addItem(self.tr("Import glyphnames…"))
         glyphSets = readGlyphSets()
         for name, glyphNames in glyphSets.items():
             self.importCharDrop.addItem(name, glyphNames)
@@ -551,12 +553,12 @@ class AddGlyphsDialog(QDialog):
         self.addGlyphsEdit = QPlainTextEdit(self)
         self.addGlyphsEdit.setFocus(True)
 
-        self.addUnicodeBox = QCheckBox("Add Unicode", self)
+        self.addUnicodeBox = QCheckBox(self.tr("Add Unicode"), self)
         self.addUnicodeBox.setChecked(True)
-        self.addAsTemplateBox = QCheckBox("Add as template", self)
+        self.addAsTemplateBox = QCheckBox(self.tr("Add as template"), self)
         self.addAsTemplateBox.setChecked(True)
-        self.sortFontBox = QCheckBox("Sort font", self)
-        self.overrideBox = QCheckBox("Override", self)
+        self.sortFontBox = QCheckBox(self.tr("Sort font"), self)
+        self.overrideBox = QCheckBox(self.tr("Override"), self)
         buttonBox = QDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         buttonBox.accepted.connect(self.accept)
@@ -615,20 +617,20 @@ class SortDialog(QDialog):
     def __init__(self, desc=None, parent=None):
         super(SortDialog, self).__init__(parent)
         self.setWindowModality(Qt.WindowModal)
-        self.setWindowTitle("Sort…")
+        self.setWindowTitle(self.tr("Sort…"))
 
-        self.smartSortBox = QRadioButton("Canned sort", self)
-        self.smartSortBox.setToolTip("A combination of simple, complex and "
-                                     "custom sorts that give optimized "
-                                     "ordering results.")
-        self.glyphSetBox = QRadioButton("Glyph set", self)
+        self.smartSortBox = QRadioButton(self.tr("Canned sort"), self)
+        self.smartSortBox.setToolTip(
+            self.tr("A combination of simple, complex and custom "
+                    "sorts that give optimized ordering results."))
+        self.glyphSetBox = QRadioButton(self.tr("Glyph set"), self)
         self.glyphSetBox.toggled.connect(self.glyphSetToggle)
         self.glyphSetDrop = QComboBox(self)
         self.glyphSetDrop.setEnabled(False)
         glyphSets = readGlyphSets()
         for name, glyphNames in glyphSets.items():
             self.glyphSetDrop.addItem(name, glyphNames)
-        self.customSortBox = QRadioButton("Custom…", self)
+        self.customSortBox = QRadioButton(self.tr("Custom…"), self)
         self.customSortBox.toggled.connect(self.customSortToggle)
 
         self.customSortGroup = QGroupBox(parent=self)
@@ -652,8 +654,8 @@ class SortDialog(QDialog):
         for i, line in enumerate(self.customDescriptors):
             line.append(QComboBox(self))
             line[0].insertItems(0, sortItems)
-            line.append(QCheckBox("Ascending", self))
-            line.append(QCheckBox("Allow pseudo-unicode", self))
+            line.append(QCheckBox(self.tr("Ascending"), self))
+            line.append(QCheckBox(self.tr("Allow pseudo-unicode"), self))
             if self.customSortBox.isChecked():
                 line[0].setCurrentIndex(
                     self.indexFromItemName(desc[i]["type"]))
@@ -732,7 +734,7 @@ class SortDialog(QDialog):
         for index, item in enumerate(sortItems):
             if name == item:
                 return index
-        print("Unknown descriptor name: %s", name)
+        print(self.tr("Unknown descriptor name: %s"), name)
         return 0
 
     @classmethod
@@ -782,11 +784,12 @@ class MainWindow(QMainWindow):
 
         menuBar = self.menuBar()
         # TODO: make shortcuts platform-independent
-        fileMenu = QMenu("&File", self)
-        fileMenu.addAction("&New…", self.newFile, QKeySequence.New)
-        fileMenu.addAction("&Open…", self.openFile, QKeySequence.Open)
+        fileMenu = QMenu(self.tr("&File"), self)
+        fileMenu.addAction(self.tr("&New…"), self.newFile, QKeySequence.New)
+        fileMenu.addAction(self.tr("&Open…"), self.openFile,
+                           QKeySequence.Open)
         # recent files
-        self.recentFilesMenu = QMenu("Open &Recent…", self)
+        self.recentFilesMenu = QMenu(self.tr("Open &Recent"), self)
         for i in range(MAX_RECENT_FILES):
             action = QAction(self.recentFilesMenu)
             action.setVisible(False)
@@ -794,60 +797,70 @@ class MainWindow(QMainWindow):
             self.recentFilesMenu.addAction(action)
         self.updateRecentFiles()
         fileMenu.addMenu(self.recentFilesMenu)
-        fileMenu.addAction("&Import…", self.importFile)
+        fileMenu.addAction(self.tr("&Import…"), self.importFile)
         fileMenu.addSeparator()
-        fileMenu.addAction("&Save", self.saveFile, QKeySequence.Save)
-        fileMenu.addAction("Save &As…", self.saveFileAs, QKeySequence.SaveAs)
-        fileMenu.addAction("&Export…", self.exportFile)
-        fileMenu.addAction("&Reload From Disk", self.reloadFile)
-        fileMenu.addAction("E&xit", self.close, QKeySequence.Quit)
+        fileMenu.addAction(self.tr("&Save"), self.saveFile, QKeySequence.Save)
+        fileMenu.addAction(self.tr("Save &As…"), self.saveFileAs,
+                           QKeySequence.SaveAs)
+        fileMenu.addAction(self.tr("&Export…"), self.exportFile)
+        fileMenu.addAction(self.tr("&Reload From Disk"), self.reloadFile)
+        fileMenu.addAction(self.tr("E&xit"), self.close, QKeySequence.Quit)
         menuBar.addMenu(fileMenu)
 
-        editMenu = QMenu("&Edit", self)
+        editMenu = QMenu(self.tr("&Edit"), self)
         self._undoAction = editMenu.addAction(
-            "&Undo", self.undo, QKeySequence.Undo)
+            self.tr("&Undo"), self.undo, QKeySequence.Undo)
         self._redoAction = editMenu.addAction(
-            "&Redo", self.redo, QKeySequence.Redo)
+            self.tr("&Redo"), self.redo, QKeySequence.Redo)
         editMenu.addSeparator()
-        self.markColorMenu = QMenu("&Flag Color", self)
+        self.markColorMenu = QMenu(self.tr("&Flag Color"), self)
         self.updateMarkColors()
         editMenu.addMenu(self.markColorMenu)
-        cut = editMenu.addAction("C&ut", self.cut, QKeySequence.Cut)
-        copy = editMenu.addAction("&Copy", self.copy, QKeySequence.Copy)
+        cut = editMenu.addAction(self.tr("C&ut"), self.cut, QKeySequence.Cut)
+        copy = editMenu.addAction(self.tr("&Copy"), self.copy,
+                                  QKeySequence.Copy)
         copyComponent = editMenu.addAction(
-            "Copy &As Component", self.copyAsComponent, "Ctrl+Alt+C")
+            self.tr("Copy &As Component"), self.copyAsComponent, "Ctrl+Alt+C")
         paste = editMenu.addAction(
-            "&Paste", self.paste, QKeySequence.Paste)
+            self.tr("&Paste"), self.paste, QKeySequence.Paste)
         self._clipboardActions = (cut, copy, copyComponent, paste)
         editMenu.addSeparator()
-        editMenu.addAction("&Settings…", self.settings)
+        editMenu.addAction(self.tr("&Settings…"), self.settings)
         menuBar.addMenu(editMenu)
 
-        fontMenu = QMenu("&Font", self)
+        fontMenu = QMenu(self.tr("&Font"), self)
         # TODO: work out sensible shortcuts and make sure they're
         # cross-platform ready - consider extracting them into separate file?
-        fontMenu.addAction("&Add Glyphs…", self.addGlyphs, "Ctrl+G")
-        fontMenu.addAction("Font &Info", self.fontInfo, "Ctrl+Alt+I")
-        fontMenu.addAction("Font &Features", self.fontFeatures, "Ctrl+Alt+F")
+        fontMenu.addAction(self.tr("&Add Glyphs…"), self.addGlyphs,
+                           "Ctrl+G")
+        fontMenu.addAction(self.tr("Font &Info"), self.fontInfo,
+                           "Ctrl+Alt+I")
+        fontMenu.addAction(self.tr("Font &Features"), self.fontFeatures,
+                           "Ctrl+Alt+F")
         fontMenu.addSeparator()
-        fontMenu.addAction("&Sort…", self.sortGlyphs)
+        fontMenu.addAction(self.tr("&Sort…"), self.sortGlyphs)
         menuBar.addMenu(fontMenu)
 
-        pythonMenu = QMenu("&Python", self)
-        pythonMenu.addAction("Scripting &Window", self.scripting, "Ctrl+Alt+R")
+        pythonMenu = QMenu(self.tr("&Python"), self)
+        pythonMenu.addAction(self.tr("Scripting &Window"), self.scripting,
+                             "Ctrl+Alt+R")
         menuBar.addMenu(pythonMenu)
 
-        windowMenu = QMenu("&Windows", self)
-        action = windowMenu.addAction("&Inspector", self.inspector, "Ctrl+I")
+        windowMenu = QMenu(self.tr("&Windows"), self)
+        action = windowMenu.addAction(self.tr("&Inspector"), self.inspector,
+                                      "Ctrl+I")
         # XXX: we're getting duplicate shortcut when we spawn a new window...
         action.setShortcutContext(Qt.ApplicationShortcut)
-        windowMenu.addAction("&Metrics Window", self.metrics, "Ctrl+Alt+S")
-        windowMenu.addAction("&Groups Window", self.groups, "Ctrl+Alt+G")
+        windowMenu.addAction(self.tr("&Metrics Window"), self.metrics,
+                             "Ctrl+Alt+S")
+        windowMenu.addAction(self.tr("&Groups Window"), self.groups,
+                             "Ctrl+Alt+G")
         menuBar.addMenu(windowMenu)
 
-        helpMenu = QMenu("&Help", self)
-        helpMenu.addAction("&About", self.about)
-        helpMenu.addAction("About &Qt", QApplication.instance().aboutQt)
+        helpMenu = QMenu(self.tr("&Help"), self)
+        helpMenu.addAction(self.tr("&About"), self.about)
+        helpMenu.addAction(self.tr("About &Qt"),
+                           QApplication.instance().aboutQt)
         menuBar.addMenu(helpMenu)
 
         self.sqSizeSlider = QSlider(Qt.Horizontal, self)
@@ -876,7 +889,7 @@ class MainWindow(QMainWindow):
 
     def openFile(self):
         path, _ = QFileDialog.getOpenFileName(
-            self, "Open File", '',
+            self, self.tr("Open File"), '',
             platformSpecific.fileFormats
         )
         if path:
@@ -907,8 +920,8 @@ class MainWindow(QMainWindow):
 
     def saveFileAs(self):
         fileFormats = OrderedDict([
-            ("UFO Font version 3 (*.ufo)", 3),
-            ("UFO Font version 2 (*.ufo)", 2),
+            (self.tr("UFO Font version 3 {}").format("(*.ufo)"), 3),
+            (self.tr("UFO Font version 2 {}").format("(*.ufo)"), 2),
         ])
         # TODO: see if OSX works nicely with UFO as files, then switch
         # to directory on platforms that need it
@@ -932,16 +945,18 @@ class MainWindow(QMainWindow):
 
         # TODO: systematize this into extractor
         fileFormats = (
-            "OpenType Font file (*.otf *.ttf)",
-            "Type1 Font file (*.pfa *.pfb)",
-            "ttx Font file (*.ttx)",
-            "WOFF Font file (*.woff)",
-            "All supported files (*.otf *.pfa *.pfb *.ttf *.ttx *.woff)",
-            "All files (*.*)",
+            self.tr("OpenType Font file {}").format("(*.otf *.ttf)"),
+            self.tr("Type1 Font file {}").format("(*.pfa *.pfb)"),
+            self.tr("ttx Font file {}").format("(*.ttx)"),
+            self.tr("WOFF Font file {}").format("(*.woff)"),
+            self.tr("All supported files {}").format(
+                "(*.otf *.pfa *.pfb *.ttf *.ttx *.woff)"),
+            self.tr("All files {}").format("(*.*)"),
         )
 
         path, _ = QFileDialog.getOpenFileName(
-            self, "Import File", None, ";;".join(fileFormats), fileFormats[4])
+            self, self.tr("Import File"), None,
+            ";;".join(fileFormats), fileFormats[4])
 
         if path:
             font = TFont()
@@ -961,13 +976,14 @@ class MainWindow(QMainWindow):
             if getattr(self.font.info, attr) is None:
                 missingAttrs.append(attr)
         if len(missingAttrs):
-            text = "Attributes required for font generation are missing: %s" \
-                   % " ".join(missingAttrs)
+            text = self.tr("Attributes required for font generation are "
+                           "missing: {}").format(" ".join(missingAttrs))
             QMessageBox.critical(self, "Export Error", text)
             return
         # go ahead
-        path, _ = QFileDialog.getSaveFileName(self, "Export File", None,
-                                              "OpenType PS font (*.otf)")
+        path, _ = QFileDialog.getSaveFileName(
+            self, self.tr("Export File"), None,
+            self.tr("OpenType PS font {}").format("(*.otf)"))
         if path:
             try:
                 otf = self.font.getRepresentation("defconQt.TTFont")
@@ -1064,15 +1080,15 @@ class MainWindow(QMainWindow):
                 # TODO: maybe cache this font name in the Font
                 currentFont = os.path.basename(self.font.path.rstrip(os.sep))
             else:
-                currentFont = "Untitled.ufo"
-            body = "Do you want to save the changes you made to “%s”?" \
-                % currentFont
+                currentFont = self.tr("Untitled.ufo")
+            body = self.tr("Do you want to save the changes you made "
+                           "to “{}”?").format(currentFont)
             closeDialog = QMessageBox(
                 QMessageBox.Question, None, body,
                 QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel,
                 self)
             closeDialog.setInformativeText(
-                "Your changes will be lost if you don’t save them.")
+                self.tr("Your changes will be lost if you don’t save them."))
             closeDialog.setModal(True)
             ret = closeDialog.exec_()
             if ret == QMessageBox.Save:
@@ -1243,7 +1259,7 @@ class MainWindow(QMainWindow):
                 count = selection
                 text = ""
             if not count == 0:
-                text = "%s(%d selected)" % (text, count)
+                text = self.tr("{0}(%n selected)".format(text), n=count)
         else:
             text = ""
         self.selectionLabel.setText(text)
@@ -1267,7 +1283,7 @@ class MainWindow(QMainWindow):
             if self.font.path is not None:
                 title = os.path.basename(self.font.path.rstrip(os.sep))
             else:
-                title = "Untitled.ufo"
+                title = self.tr("Untitled.ufo")
         super(MainWindow, self).setWindowTitle("[*]{}".format(title))
 
     def fontInfo(self):
@@ -1371,20 +1387,21 @@ class MainWindow(QMainWindow):
     def about(self):
         name = QApplication.applicationName()
         domain = QApplication.organizationDomain()
-        text = "<h3>About {n}</h3>" \
-            "<p>{n} is a cross-platform, modular typeface design " \
-            "application.</p><p>{n} is built on top of " \
-            "<a href='http://ts-defcon.readthedocs.org/en/ufo3/'>defcon</a> " \
-            "and includes scripting support " \
-            "with a <a href='http://robofab.com/'>robofab</a>-like API.</p>" \
-            "<p>Version {} {} – Python {}.".format(
-                __version__, gitShortHash, platform.python_version(), n=name)
+        text = self.tr(
+            "<h3>About {n}</h3>"
+            "<p>{n} is a cross-platform, modular typeface design "
+            "application.</p><p>{n} is built on top of "
+            "<a href='http://ts-defcon.readthedocs.org/en/ufo3/'>defcon</a> "
+            "and includes scripting support "
+            "with a <a href='http://robofab.com/'>robofab</a>-like API.</p>"
+            "<p>Version {} {} – Python {}.").format(
+            __version__, gitShortHash, platform.python_version(), n=name)
         if domain:
-            text += "<br>See <a href='http://{d}'>{d}</a> for more " \
-                    "information.</p>".format(d=domain)
+            text += self.tr("<br>See <a href='http://{d}'>{d}</a> for more "
+                            "information.</p>").format(d=domain)
         else:
             text += "</p>"
-        QMessageBox.about(self, "About {}".format(name), text)
+        QMessageBox.about(self, self.tr("About {}").format(name), text)
 
 
 class SettingsDialog(QDialog):
@@ -1392,12 +1409,13 @@ class SettingsDialog(QDialog):
     def __init__(self, parent=None):
         super(SettingsDialog, self).__init__(parent)
         # self.setWindowModality(Qt.WindowModal)
-        self.setWindowTitle("Settings")
+        self.setWindowTitle(self.tr("Settings"))
 
         self.tabWidget = QTabWidget(self)
-        self.tabWidget.addTab(GlyphSetTab(self), "Glyph sets")
-        self.tabWidget.addTab(MetricsWindowTab(self), "Metrics Window")
-        self.tabWidget.addTab(MiscTab(self), "Misc")
+        self.tabWidget.addTab(GlyphSetTab(self), self.tr("Glyph sets"))
+        self.tabWidget.addTab(MetricsWindowTab(self),
+                              self.tr("Metrics Window"))
+        self.tabWidget.addTab(MiscTab(self), self.tr("Misc"))
 
         buttonBox = QDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
@@ -1448,7 +1466,8 @@ class GlyphSetTab(QWidget):
         super().__init__(parent)
 
         settings = QSettings()
-        self.defaultGlyphSetBox = QCheckBox("Default glyph set:", self)
+        self.defaultGlyphSetBox = QCheckBox(self.tr("Default glyph set:"),
+                                            self)
         self.defaultGlyphSetDrop = QComboBox(self)
         defaultGlyphSet = settings.value(
             "settings/defaultGlyphSet", latinDefault.name, str)
@@ -1481,18 +1500,18 @@ class GlyphSetTab(QWidget):
         self.removeGlyphSetButton = QPushButton("−", self)
         self.removeGlyphSetButton.setEnabled(len(self.glyphSets) > 1)
         self.removeGlyphSetButton.clicked.connect(self.removeGlyphSet)
-        self.importButton = QPushButton("Import", self)
+        self.importButton = QPushButton(self.tr("Import"), self)
         importMenu = QMenu(self)
-        importMenu.addAction("Import from current font",
+        importMenu.addAction(self.tr("Import from current font"),
                              self.importFromCurrentFont)
         self.importButton.setMenu(importMenu)
         glyphListPath = settings.value("settings/glyphListPath", type=str)
-        self.glyphListBox = QCheckBox("Glyph list path:", self)
+        self.glyphListBox = QCheckBox(self.tr("Glyph list path:"), self)
         self.glyphListBox.setChecked(bool(glyphListPath))
         self.glyphListEdit = QLineEdit(glyphListPath, self)
         self.glyphListEdit.setEnabled(bool(glyphListPath))
         self.glyphListEdit.setReadOnly(True)
-        self.glyphListButton = QPushButton("Browse…", self)
+        self.glyphListButton = QPushButton(self.tr("Browse…"), self)
         self.glyphListButton.setEnabled(bool(glyphListPath))
         self.glyphListButton.clicked.connect(self.getGlyphList)
         self.glyphListButton.setFixedWidth(72)
@@ -1518,7 +1537,9 @@ class GlyphSetTab(QWidget):
         mainLayout.addLayout(secondLayout)
         self.setLayout(mainLayout)
 
-    def addGlyphSet(self, glyphNames=[], glyphSetName="New glyph set"):
+    def addGlyphSet(self, glyphNames=[], glyphSetName=None):
+        if glyphSetName is None:
+            glyphSetName = self.tr("New glyph set")
         if glyphSetName in self.glyphSets:
             index = 1
             while "%s %d" % (glyphSetName, index) in self.glyphSets:
@@ -1584,11 +1605,11 @@ class GlyphSetTab(QWidget):
 
     def getGlyphList(self):
         fileFormats = (
-            "Text file (*.txt)",
-            "All files (*.*)",
+            self.tr("Text file {}").format("(*.txt)"),
+            self.tr("All files {}").format("(*.*)"),
         )
         path, _ = QFileDialog.getOpenFileName(
-            self, "Open File", '', ";;".join(fileFormats)
+            self, self.tr("Open File"), '', ";;".join(fileFormats)
         )
         if path:
             self.glyphListEdit.setText(path)
@@ -1618,7 +1639,7 @@ class MetricsWindowTab(QWidget):
         super().__init__(parent)
 
         settings = QSettings()
-        self.inputTextLabel = QLabel("Default text:", self)
+        self.inputTextLabel = QLabel(self.tr("Default text:"), self)
         self.inputTextList = QListWidget(self)
         self.inputTextList.setDragDropMode(QAbstractItemView.InternalMove)
         entries = settings.value("metricsWindow/comboBoxItems", comboBoxItems,
@@ -1696,16 +1717,18 @@ class MiscTab(QWidget):
 
         settings = QSettings()
         loadRecentFile = settings.value("misc/loadRecentFile", False, bool)
-        self.loadRecentFileBox = QCheckBox("Load most recent file on start",
-                                           self)
+        self.loadRecentFileBox = QCheckBox(
+            self.tr("Load most recent file on start"), self)
         self.loadRecentFileBox.setChecked(loadRecentFile)
 
-        self.markColorLabel = QLabel("Default flag colors:", self)
+        self.markColorLabel = QLabel(self.tr("Default flag colors:"), self)
         # TODO: enforce duplicate names avoidance
         self.markColorWidget = QTreeWidget(self)
-        self.markColorWidget.setHeaderLabels(("Color", "Name"))
+        self.markColorWidget.setHeaderLabels((self.tr("Color"),
+                                              self.tr("Name")))
         self.markColorWidget.setRootIsDecorated(False)
-        self.markColorWidget.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.markColorWidget.setSelectionBehavior(
+            QAbstractItemView.SelectRows)
         # TODO: make this work correctly, top-level items only
         # self.markColorWidget.setDragDropMode(QAbstractItemView.InternalMove)
         entries = readMarkColors(settings)
@@ -1740,11 +1763,11 @@ class MiscTab(QWidget):
     def addItem(self):
 
         def mangleNewName():
-            name = "New"
+            name = self.tr("New")
             index = 0
             while self.markColorWidget.findItems(name, Qt.MatchExactly, 1):
                 index += 1
-                name = "New ({})".format(index)
+                name = "{0} ({1})".format(name, index)
             return name
 
         # TODO: not DRY with ctor

--- a/Lib/defconQt/glyphCollectionView.py
+++ b/Lib/defconQt/glyphCollectionView.py
@@ -30,11 +30,18 @@ arrowKeys = (Qt.Key_Up, Qt.Key_Down, Qt.Key_Left, Qt.Key_Right)
 
 
 def proceedWithDeletion(self, erase=False):
-    do = "clear" if not erase else "delete"
+    clear_header = QApplication.translate(
+        "GlyphCollectionWidget", "Clear glyphs")
+    clear_text = QApplication.translate(
+        "GlyphCollectionWidget", "Do you want to clear selected glyphs?")
+    erase_header = QApplication.translate(
+        "GlyphCollectionWidget", "Delete glyphs")
+    erase_text = QApplication.translate(
+        "GlyphCollectionWidget", "Do you want to delete selected glyphs?")
     closeDialog = QMessageBox(
-        QMessageBox.Question, "", "%s glyphs" % do.capitalize(),
+        QMessageBox.Question, "", clear_header if not erase else erase_header,
         QMessageBox.Yes | QMessageBox.No, self)
-    closeDialog.setInformativeText("Do you want to %s selected glyphs?" % do)
+    closeDialog.setInformativeText(clear_text if not erase else erase_text)
     closeDialog.setModal(True)
     ret = closeDialog.exec_()
     if ret == QMessageBox.Yes:

--- a/Lib/defconQt/glyphView.py
+++ b/Lib/defconQt/glyphView.py
@@ -25,47 +25,50 @@ class MainGlyphWindow(QMainWindow):
         super().__init__(parent)
 
         menuBar = self.menuBar()
-        fileMenu = QMenu("&File", self)
-        fileMenu.addAction("E&xit", self.close, QKeySequence.Quit)
+        fileMenu = QMenu(self.tr("&File"), self)
+        fileMenu.addAction(self.tr("&Close"), self.close, QKeySequence.Quit)
         menuBar.addMenu(fileMenu)
-        editMenu = QMenu("&Edit", self)
+        editMenu = QMenu(self.tr("&Edit"), self)
         self._undoAction = editMenu.addAction(
-            "&Undo", self.undo, QKeySequence.Undo)
+            self.tr("&Undo"), self.undo, QKeySequence.Undo)
         self._redoAction = editMenu.addAction(
-            "&Redo", self.redo, QKeySequence.Redo)
+            self.tr("&Redo"), self.redo, QKeySequence.Redo)
         editMenu.addSeparator()
         # XXX
-        action = editMenu.addAction("C&ut", self.cutOutlines, QKeySequence.Cut)
+        action = editMenu.addAction(self.tr("C&ut"), self.cutOutlines,
+                                    QKeySequence.Cut)
         action.setEnabled(False)
         self._copyAction = editMenu.addAction(
-            "&Copy", self.copyOutlines, QKeySequence.Copy)
-        editMenu.addAction("&Paste", self.pasteOutlines, QKeySequence.Paste)
+            self.tr("&Copy"), self.copyOutlines, QKeySequence.Copy)
+        editMenu.addAction(self.tr("&Paste"), self.pasteOutlines,
+                           QKeySequence.Paste)
         editMenu.addAction(
-            "Select &All", self.selectAll, QKeySequence.SelectAll)
-        editMenu.addAction("&Deselect", self.deselect, "Ctrl+D")
+            self.tr("Select &All"), self.selectAll, QKeySequence.SelectAll)
+        editMenu.addAction(self.tr("&Deselect"), self.deselect, "Ctrl+D")
         menuBar.addMenu(editMenu)
-        glyphMenu = QMenu("&Glyph", self)
-        glyphMenu.addAction("&Next Glyph", lambda: self.glyphOffset(1), "End")
+        glyphMenu = QMenu(self.tr("&Glyph"), self)
+        glyphMenu.addAction(self.tr("&Next Glyph"),
+                            lambda: self.glyphOffset(1), "End")
         glyphMenu.addAction(
-            "&Previous Glyph", lambda: self.glyphOffset(-1), "Home")
-        glyphMenu.addAction("&Go To…", self.changeGlyph, "G")
+            self.tr("&Previous Glyph"), lambda: self.glyphOffset(-1), "Home")
+        glyphMenu.addAction(self.tr("&Go To…"), self.changeGlyph, "G")
         glyphMenu.addSeparator()
         self._layerAction = glyphMenu.addAction(
-            "&Layer Actions…", self.layerActions, "L")
+            self.tr("&Layer Actions…"), self.layerActions, "L")
         menuBar.addMenu(glyphMenu)
 
         # create tools and buttons toolBars
         self._tools = []
-        self._toolsToolBar = QToolBar("Tools", self)
+        self._toolsToolBar = QToolBar(self.tr("Tools"), self)
         self._toolsToolBar.setMovable(False)
         self._buttons = []
-        self._buttonsToolBar = QToolBar("Buttons", self)
+        self._buttonsToolBar = QToolBar(self.tr("Buttons"), self)
         self._buttonsToolBar.setMovable(False)
         self.addToolBar(self._toolsToolBar)
         self.addToolBar(self._buttonsToolBar)
 
         # http://www.setnode.com/blog/right-aligning-a-button-in-a-qtoolbar/
-        self._layersToolBar = QToolBar("Layers", self)
+        self._layersToolBar = QToolBar(self.tr("Layers"), self)
         spacer = QWidget()
         spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self._currentLayerBox = QComboBox(self)
@@ -78,9 +81,10 @@ class MainGlyphWindow(QMainWindow):
         self.addToolBar(self._layersToolBar)
 
         viewMenu = self.createPopupMenu()
-        viewMenu.setTitle("View")
+        viewMenu.setTitle(self.tr("View"))
         viewMenu.addSeparator()
-        action = viewMenu.addAction("Lock Toolbars", self.lockToolBars)
+        action = viewMenu.addAction(self.tr("Lock Toolbars"),
+                                    self.lockToolBars)
         action.setCheckable(True)
         action.setChecked(True)
         menuBar.addMenu(viewMenu)
@@ -432,7 +436,7 @@ class MainGlyphWindow(QMainWindow):
         for layer in glyph.layerSet:
             comboBox.addItem(layer.name, layer)
         comboBox.setCurrentText(glyph.layer.name)
-        comboBox.addItem("New layer…", None)
+        comboBox.addItem(self.tr("New layer…"), None)
         comboBox.blockSignals(False)
         self._layerAction.setEnabled(len(glyph.layerSet) > 1)
 

--- a/Lib/defconQt/groupsView.py
+++ b/Lib/defconQt/groupsView.py
@@ -156,8 +156,8 @@ class GroupsWindow(QWidget):
         if not groups:
             self.removeGroupButton.setEnabled(False)
 
-        self.alignLeftBox = QRadioButton("Align left", self)
-        self.alignRightBox = QRadioButton("Align right", self)
+        self.alignLeftBox = QRadioButton(self.tr("Align left"), self)
+        self.alignRightBox = QRadioButton(self.tr("Align right"), self)
         self.alignLeftBox.setChecked(True)
         self.alignLeftBox.toggled.connect(self._alignmentChanged)
         self._autoDirection = True
@@ -183,7 +183,9 @@ class GroupsWindow(QWidget):
 
         self.setWindowTitle(font=self.font)
 
-    def setWindowTitle(self, title="Groups Window", font=None):
+    def setWindowTitle(self, title=None, font=None):
+        if title is None:
+            title = self.tr("Groups Window")
         if font is not None:
             title = "%s – %s %s" % (
                 title, font.info.familyName, font.info.styleName)
@@ -194,7 +196,7 @@ class GroupsWindow(QWidget):
         self.stackWidget.setAlignment(alignRight)
 
     def _groupAdd(self):
-        groupName = "New group"
+        groupName = self.tr("New group")
         if groupName in self.font.groups:
             index = 1
             while "%s %d" % (groupName, index) in self.font.groups:

--- a/Lib/defconQt/metricsWindow.py
+++ b/Lib/defconQt/metricsWindow.py
@@ -8,7 +8,7 @@ from PyQt5.QtGui import (
     QBrush, QColor, QIcon, QIntValidator, QKeySequence, QPainter, QPalette,
     QPen)
 from PyQt5.QtWidgets import (
-    QAbstractItemView, QActionGroup, QApplication, QComboBox, QLineEdit, QMenu,
+    QAbstractItemView, QApplication, QComboBox, QLineEdit, QMenu,
     QPushButton, QScrollArea, QStyledItemDelegate, QTableWidget,
     QTableWidgetItem, QVBoxLayout, QSizePolicy, QToolBar, QWidget)
 import re
@@ -41,10 +41,9 @@ class MainMetricsWindow(QWidget):
 
         if string is None:
             try:
-                string = getuser()
+                string = self.tr("Hello {0}").format(getuser())
             except:
-                string = "World"
-            string = "Hello %s" % string
+                string = self.tr("Hello World")
         # TODO: drop self.font and self.glyphs, store in the widgets only
         self.font = font
         self.glyphs = []
@@ -77,12 +76,14 @@ class MainMetricsWindow(QWidget):
         self.setWindowTitle(font=self.font)
 
     def setupFileMenu(self):
-        fileMenu = QMenu("&File", self)
-        fileMenu.addAction("&Save…", self.save, QKeySequence.Save)
-        fileMenu.addAction("E&xit", self.close, QKeySequence.Quit)
+        fileMenu = QMenu(self.tr("&File"), self)
+        fileMenu.addAction(self.tr("&Save…"), self.save, QKeySequence.Save)
+        fileMenu.addAction(self.tr("&Close"), self.close, QKeySequence.Quit)
         self.menuBar().addMenu(fileMenu)
 
-    def setWindowTitle(self, title="Metrics Window", font=None):
+    def setWindowTitle(self, title=None, font=None):
+        if title is None:
+            title = self.tr("Metrics Window")
         if font is not None:
             title = "%s – %s %s" % (
                 title, font.info.familyName, font.info.styleName)
@@ -257,18 +258,19 @@ class FontToolBar(QToolBar):
         self.configBar.setStyleSheet("padding: 2px 0px; padding-right: 10px")
         self.toolsMenu = QMenu(self)
         showKerning = self.toolsMenu.addAction(
-            "Show Kerning", self.showKerning)
+            self.tr("Show Kerning"), self.showKerning)
         showKerning.setCheckable(True)
         showMetrics = self.toolsMenu.addAction(
-            "Show Metrics", self.showMetrics)
+            self.tr("Show Metrics"), self.showMetrics)
         showMetrics.setCheckable(True)
         self.toolsMenu.addSeparator()
-        wrapLines = self.toolsMenu.addAction("Wrap lines", self.wrapLines)
+        wrapLines = self.toolsMenu.addAction(self.tr("Wrap lines"),
+                                             self.wrapLines)
         wrapLines.setCheckable(True)
         wrapLines.setChecked(True)
         self.toolsMenu.addSeparator()
         verticalFlip = self.toolsMenu.addAction(
-            "Vertical flip", self.verticalFlip)
+            self.tr("Vertical flip"), self.verticalFlip)
         verticalFlip.setCheckable(True)
         """
         lineHeight = QWidgetAction(self.toolsMenu)
@@ -740,7 +742,7 @@ class SpaceTable(QTableWidget):
         super(SpaceTable, self).__init__(4, 1, parent)
         self.setAttribute(Qt.WA_KeyCompression)
         self.setItemDelegate(GlyphCellItemDelegate(self))
-        data = [None, "Width", "Left", "Right"]
+        data = [None, self.tr("Width"), self.tr("Left"), self.tr("Right")]
         # Don't grey-out disabled cells
         palette = self.palette()
         fgColor = palette.color(QPalette.Text)

--- a/Lib/defconQt/objects/glyphDialogs.py
+++ b/Lib/defconQt/objects/glyphDialogs.py
@@ -1,7 +1,7 @@
 from PyQt5.QtCore import QEvent, Qt
 from PyQt5.QtWidgets import (
     QDialog, QDialogButtonBox, QGridLayout, QLabel, QLineEdit, QListWidget,
-    QRadioButton)
+    QRadioButton, QApplication)
 
 
 class GotoDialog(QDialog):
@@ -12,20 +12,23 @@ class GotoDialog(QDialog):
     def __init__(self, currentGlyph, parent=None):
         super(GotoDialog, self).__init__(parent)
         self.setWindowModality(Qt.WindowModal)
-        self.setWindowTitle("Go to…")
+        self.setWindowTitle(self.tr("Go to…"))
         self.font = currentGlyph.getParent()
         self._sortedGlyphs = self.font.unicodeData.sortGlyphNames(
             self.font.keys(), self.alphabetical)
 
         layout = QGridLayout(self)
-        self.glyphLabel = QLabel("Glyph:", self)
+        self.glyphLabel = QLabel(
+            QApplication.translate("GotoDialog", "Glyph:"), self)
         self.glyphEdit = QLineEdit(self)
         self.glyphEdit.textChanged.connect(self.updateGlyphList)
         self.glyphEdit.event = self.lineEvent
         self.glyphEdit.keyPressEvent = self.lineKeyPressEvent
 
-        self.beginsWithBox = QRadioButton("Begins with", self)
-        self.containsBox = QRadioButton("Contains", self)
+        self.beginsWithBox = QRadioButton(QApplication.translate(
+            "GotoDialog", "Begins with"), self)
+        self.containsBox = QRadioButton(QApplication.translate(
+            "GotoDialog", "Contains"), self)
         self.beginsWithBox.setChecked(True)
         self.beginsWithBox.toggled.connect(self.updateGlyphList)
 
@@ -100,18 +103,18 @@ class AddAnchorDialog(QDialog):
         super(AddAnchorDialog, self).__init__(parent)
         self.setWindowModality(Qt.WindowModal)
         if pos is not None:
-            self.setWindowTitle("Add anchor…")
+            self.setWindowTitle(self.tr("Add anchor…"))
         else:
-            self.setWindowTitle("Rename anchor…")
+            self.setWindowTitle(self.tr("Rename anchor…"))
 
         layout = QGridLayout(self)
 
-        anchorNameLabel = QLabel("Anchor name:", self)
+        anchorNameLabel = QLabel(self.tr("Anchor name:"), self)
         self.anchorNameEdit = QLineEdit(self)
         self.anchorNameEdit.setFocus(True)
         if pos is not None:
             anchorPositionLabel = QLabel(
-                "The anchor will be added at ({}, {})."
+                self.tr("The anchor will be added at ({}, {}).")
                 .format(round(pos.x(), 2), round(pos.y(), 2)), self)
 
         buttonBox = QDialogButtonBox(
@@ -142,7 +145,7 @@ class AddComponentDialog(GotoDialog):
 
     def __init__(self, *args, **kwargs):
         super(AddComponentDialog, self).__init__(*args, **kwargs)
-        self.setWindowTitle("Add component…")
+        self.setWindowTitle(self.tr("Add component…"))
         self._sortedGlyphs.remove(args[0].name)
         self.updateGlyphList(False)
 
@@ -152,11 +155,11 @@ class AddLayerDialog(QDialog):
     def __init__(self, parent=None):
         super(AddLayerDialog, self).__init__(parent)
         self.setWindowModality(Qt.WindowModal)
-        self.setWindowTitle("Add layer…")
+        self.setWindowTitle(self.tr("Add layer…"))
 
         layout = QGridLayout(self)
 
-        layerNameLabel = QLabel("Layer name:", self)
+        layerNameLabel = QLabel(self.tr("Layer name:"), self)
         self.layerNameEdit = QLineEdit(self)
         self.layerNameEdit.setFocus(True)
 
@@ -185,7 +188,7 @@ class LayerActionsDialog(QDialog):
     def __init__(self, currentGlyph, parent=None):
         super().__init__(parent)
         self.setWindowModality(Qt.WindowModal)
-        self.setWindowTitle("Layer actions…")
+        self.setWindowTitle(self.tr("Layer actions…"))
         self._workableLayers = []
         for layer in currentGlyph.layerSet:
             if layer != currentGlyph.layer:
@@ -193,9 +196,9 @@ class LayerActionsDialog(QDialog):
 
         layout = QGridLayout(self)
 
-        copyBox = QRadioButton("Copy", self)
-        moveBox = QRadioButton("Move", self)
-        swapBox = QRadioButton("Swap", self)
+        copyBox = QRadioButton(self.tr("Copy"), self)
+        moveBox = QRadioButton(self.tr("Move"), self)
+        swapBox = QRadioButton(self.tr("Swap"), self)
         self.otherCheckBoxes = (moveBox, swapBox)
         copyBox.setChecked(True)
 

--- a/Lib/defconQt/scriptingWindow.py
+++ b/Lib/defconQt/scriptingWindow.py
@@ -15,14 +15,14 @@ class MainScriptingWindow(QMainWindow):
         self.editor = PythonEditor(parent=self)
         self.resize(600, 500)
 
-        fileMenu = QMenu("&File", self)
-        fileMenu.addAction("&Run…", self.runScript, "Ctrl+R")
+        fileMenu = QMenu(self.tr("&File"), self)
+        fileMenu.addAction(self.tr("&Run…"), self.runScript, "Ctrl+R")
         fileMenu.addSeparator()
-        fileMenu.addAction("E&xit", self.close, QKeySequence.Quit)
+        fileMenu.addAction(self.tr("&Close"), self.close, QKeySequence.Quit)
         self.menuBar().addMenu(fileMenu)
 
         self.setCentralWidget(self.editor)
-        self.setWindowTitle("[*]Untitled.py")
+        self.setWindowTitle(self.tr("[*]Untitled.py"))
         self.editor.modificationChanged.connect(self.setWindowModified)
 
     def runScript(self):

--- a/Lib/defconQt/tools/baseButton.py
+++ b/Lib/defconQt/tools/baseButton.py
@@ -1,8 +1,9 @@
 from PyQt5.QtCore import QObject
+from PyQt5.QtWidgets import QApplication
 
 
 class BaseButton(QObject):
-    name = "Button"
+    name = QApplication.translate("BaseButton", "Button")
     iconPath = None
 
     def __init__(self, parent=None):

--- a/Lib/defconQt/tools/baseTool.py
+++ b/Lib/defconQt/tools/baseTool.py
@@ -1,10 +1,11 @@
 from math import copysign
 from PyQt5.QtCore import QObject
 from PyQt5.QtGui import QCursor
+from PyQt5.QtWidgets import QApplication
 
 
 class BaseTool(QObject):
-    name = "Tool"
+    name = QApplication.translate("BaseTool", "Tool")
     cursor = QCursor()
     iconPath = None
 

--- a/Lib/defconQt/tools/knifeTool.py
+++ b/Lib/defconQt/tools/knifeTool.py
@@ -3,10 +3,11 @@ from defconQt.tools.baseTool import BaseTool
 from defconQt.util import bezierMath
 from PyQt5.QtCore import QLineF, Qt
 from PyQt5.QtGui import QPainterPath
+from PyQt5.QtWidgets import QApplication
 
 
 class KnifeTool(BaseTool):
-    name = "Knife"
+    name = QApplication.translate("KnifeTool", "Knife")
     iconPath = ":/resources/cutter.svg"
 
     def __init__(self, parent=None):

--- a/Lib/defconQt/tools/penTool.py
+++ b/Lib/defconQt/tools/penTool.py
@@ -2,10 +2,11 @@ from defconQt.objects.defcon import TContour
 from defconQt.tools.baseTool import BaseTool
 from defconQt.util.uiMethods import moveUIPoint
 from PyQt5.QtCore import QPointF, Qt
+from PyQt5.QtWidgets import QApplication
 
 
 class PenTool(BaseTool):
-    name = "Pen"
+    name = QApplication.translate("PenTool", "Pen")
     iconPath = ":/resources/curve.svg"
 
     def __init__(self, parent=None):

--- a/Lib/defconQt/tools/removeOverlapButton.py
+++ b/Lib/defconQt/tools/removeOverlapButton.py
@@ -1,3 +1,4 @@
+from PyQt5.QtWidgets import QApplication
 from defconQt.tools.baseButton import BaseButton
 
 
@@ -18,7 +19,7 @@ def removeSelectionOverlap(glyph):
 
 
 class RemoveOverlapButton(BaseButton):
-    name = "Remove Overlap"
+    name = QApplication.translate("RemoveOverlapButton", "Remove Overlap")
     iconPath = ":resources/union.svg"
 
     def clicked(self):

--- a/Lib/defconQt/tools/rulerTool.py
+++ b/Lib/defconQt/tools/rulerTool.py
@@ -2,10 +2,11 @@ from defconQt.tools.baseTool import BaseTool
 from defconQt.util import drawing
 from PyQt5.QtCore import QLineF, QPointF, Qt
 from PyQt5.QtGui import QPainterPath
+from PyQt5.QtWidgets import QApplication
 
 
 class RulerTool(BaseTool):
-    name = "Ruler"
+    name = QApplication.translate("RulerTool", "Ruler")
     iconPath = ":/resources/ruler.svg"
 
     def __init__(self, parent=None):

--- a/Lib/defconQt/tools/selectionTool.py
+++ b/Lib/defconQt/tools/selectionTool.py
@@ -5,14 +5,15 @@ from defconQt.util import bezierMath, platformSpecific
 from defconQt.util.uiMethods import moveUISelection, removeUISelection
 from PyQt5.QtCore import QPointF, QRectF, Qt
 from PyQt5.QtGui import QPainter, QTransform
-from PyQt5.QtWidgets import QMenu, QRubberBand, QStyle, QStyleOptionRubberBand
+from PyQt5.QtWidgets import (
+    QMenu, QRubberBand, QStyle, QStyleOptionRubberBand, QApplication)
 
 arrowKeys = (Qt.Key_Left, Qt.Key_Up, Qt.Key_Right, Qt.Key_Down)
 navKeys = (Qt.Key_Less, Qt.Key_Greater)
 
 
 class SelectionTool(BaseTool):
-    name = "Selection"
+    name = QApplication.translate("SelectionTool", "Selection")
     iconPath = ":/resources/cursor.svg"
 
     def __init__(self, parent=None):
@@ -135,15 +136,15 @@ class SelectionTool(BaseTool):
         widget = self.parent()
         self._cachedPos = event.globalPos()
         menu = QMenu(widget)
-        menu.addAction("Add Anchor…", self._createAnchor)
-        menu.addAction("Add Component…", self._createComponent)
-        menu.addAction("Reverse", self._reverse)
+        menu.addAction(self.tr("Add Anchor…"), self._createAnchor)
+        menu.addAction(self.tr("Add Component…"), self._createComponent)
+        menu.addAction(self.tr("Reverse"), self._reverse)
         itemTuple = widget.itemAt(event.localPos())
         if itemTuple is not None:
             item, parent = itemTuple
             if parent is not None and item.segmentType:
                 menu.addSeparator()
-                menu.addAction("Set Start Point",
+                menu.addAction(self.tr("Set Start Point"),
                                lambda: self._setStartPoint(item, parent))
         menu.exec_(self._cachedPos)
         self._cachedPos = None

--- a/Lib/defconQt/translations.pro
+++ b/Lib/defconQt/translations.pro
@@ -1,0 +1,49 @@
+# This file collects 
+# 1. All files with code that should be scanned for user-visible text.
+# 2. All target languages and where to put those translations.
+#
+# Usage:
+#   1. In the source, when inside a class derived from QObject that preferably
+#      is not to be derived from or mixed with others[1], use `self.tr("Some
+#      user visible text")` instead of the bare string to mark it for
+#      translation. When outside a QObject-derived class (e.g. a stand-alone
+#      function), use `QCoreApplication.translate('context, e.g. stand-alone
+#      function', "Some user visible text")`.
+#   2. Add the file here unless already present.
+#   3. Run `pylupdate5 translations.pro`. This will scan all (Python) source 
+#      files and update the translation files if necessary. Previous
+#      translations will stay, new and changed strings will be marked. The
+#      generated .ts files are for translators to work on in Qt Linguist[2].
+#   4. Once translators have forked over their translations, run 
+#      `lrelease translations.pro` (exact lrelease name might vary). This
+#      compiles .ts files into .qm files that are then loaded by application
+#      code.
+#
+# [1]: http://pyqt.sourceforge.net/Docs/PyQt5/i18n.html#differences-between-pyqt5-and-qt
+# [2]: https://doc.qt.io/qt-5/linguist-translators.html
+
+CODECFORTR = UTF-8
+CODECFORSRC = UTF-8
+
+SOURCES += __main__.py \
+           glyphCollectionView.py \
+           featureTextEditor.py \
+           fontInfo.py \
+           fontView.py \
+           glyphView.py \
+           groupsView.py \
+           metricsWindow.py \
+           scriptingWindow.py \
+           objects/glyphDialogs.py \
+           tools/baseButton.py \
+           tools/baseTool.py \
+           tools/knifeTool.py \
+           tools/penTool.py \
+           tools/removeOverlapButton.py \
+           tools/rulerTool.py \
+           tools/selectionTool.py \
+           util/drawing.py \
+           util/glyphList.py \
+           util/platformSpecific.py
+
+TRANSLATIONS += resources/trufont_de.ts

--- a/Lib/defconQt/translations.pro
+++ b/Lib/defconQt/translations.pro
@@ -7,7 +7,7 @@
 #      is not to be derived from or mixed with others[1], use `self.tr("Some
 #      user visible text")` instead of the bare string to mark it for
 #      translation. When outside a QObject-derived class (e.g. a stand-alone
-#      function), use `QCoreApplication.translate('context, e.g. stand-alone
+#      function), use `QApplication.translate('context, e.g. stand-alone
 #      function', "Some user visible text")`.
 #   2. Add the file here unless already present.
 #   3. Run `pylupdate5 translations.pro`. This will scan all (Python) source 

--- a/Lib/defconQt/util/drawing.py
+++ b/Lib/defconQt/util/drawing.py
@@ -2,6 +2,7 @@ from defcon import Color
 from PyQt5.QtCore import QPointF, QRectF, Qt
 from PyQt5.QtGui import (
     QBrush, QColor, QPainter, QPainterPath, QPen, QTransform)
+from PyQt5.QtWidgets import QApplication
 import traceback
 
 """
@@ -168,11 +169,15 @@ def drawFontVerticalMetrics(painter, glyph, scale, rect, drawLines=True,
     painter.setPen(color)
     # gather y positions
     toDraw = [
-        ("Descender", font.info.descender),
-        ("Baseline", 0),
-        ("x-height", font.info.xHeight),
-        ("Cap height", font.info.capHeight),
-        ("Ascender", font.info.ascender),
+        (QApplication.translate("drawing", "Descender"),
+            font.info.descender),
+        (QApplication.translate("drawing", "Baseline"), 0),
+        (QApplication.translate("drawing", "x-height"),
+            font.info.xHeight),
+        (QApplication.translate("drawing", "Cap height"),
+            font.info.capHeight),
+        (QApplication.translate("drawing", "Ascender"),
+            font.info.ascender),
     ]
     positions = {}
     for name, position in toDraw:

--- a/Lib/defconQt/util/glyphList.py
+++ b/Lib/defconQt/util/glyphList.py
@@ -1,4 +1,5 @@
 import re
+from PyQt5.QtWidgets import QApplication
 
 _parseGL_RE = re.compile("([A-Za-z_0-9.]+);([0-9A-F]{4})")
 
@@ -11,11 +12,16 @@ def parseGlyphList(path):
                 continue
             m = _parseGL_RE.match(line)
             if not m:
-                raise SyntaxError("syntax error in glyphlist: {}"
-                                  .format(repr(line[:20])))
+                raise SyntaxError(
+                    QApplication.translate(
+                        "parseGlyphList",
+                        "syntax error in glyphlist: {}").format(
+                        repr(line[:20])))
             glyphName = m.group(1)
             if glyphName in GL2UV:
-                print("warning: glyphName redefined in glyphList: {}".format(
+                print(QApplication.translate(
+                    "parseGlyphList",
+                    "warning: glyphName redefined in glyphList: {}").format(
                     glyphName))
             GL2UV[glyphName] = int(m.group(2), 16)
     return GL2UV

--- a/Lib/defconQt/util/platformSpecific.py
+++ b/Lib/defconQt/util/platformSpecific.py
@@ -1,14 +1,16 @@
 from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QApplication
 import sys
 
 # -----------
 # File dialog
 # -----------
+_ufoFileFormat = QApplication.translate("File dialog", "UFO Fonts {}")
 
 if sys.platform == "darwin":
-    fileFormats = "UFO Fonts (*.ufo)"
+    fileFormats = _ufoFileFormat.format("(*.ufo)")
 else:
-    fileFormats = "UFO Fonts (metainfo.plist)"
+    fileFormats = _ufoFileFormat.format("(metainfo.plist)")
 
 # ---------
 # Font size


### PR DESCRIPTION
I'd like to get this in, but maybe without my example translation. As long as the HIG/UI has not stabilized, it is only useful for testing.

Known problems:
- Translations don't load when starting via `trufont` -- package into resource file?
- `pylupdate5` gets confused when strings contain non-ASCII characters. Either avoid or escape them (quotation marks!) or attach them afterwards (ellipsis).

Notes:
- When sizing elements like buttons and columns, don't set a fixed width based on the length of English words. I'd fix fontView.py's glyphListButton if I knew why sizeHint() makes it so wide.