### PR TITLE
[README.md] add install info on python 3, pyqt5 and virtual environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,34 @@ PyQt5.
 
 ## Getting started
 
-1. Install dependencies with `pip3 install -r requirements.txt`
+1. Install Python 3 
+    - OS X: `brew install python3 && brew linkapps python3`
+    - Windows: Download installer from https://www.python.org/downloads/
+    - Linux: It's usually packaged with the OS.
 
-2. Install using `python setup.py install && trufont` or run under virtualenv:
-   `cd Lib && python -m defconQt`
+2. Install PyQt5:
+    - OS X: `brew install pyqt5`
+    - Windows: You can download the binary installers (32 or 64 bit) from:
+        https://riverbankcomputing.com/software/pyqt/download5
+    - Linux: Follow instructions to compile PyQt5 (and SIP) from source:
+        http://pyqt.sourceforge.net/Docs/PyQt5/installation.html
+
+3. Set up a new virtual environment using `pyvenv` (or `virtualenv`), and give
+    it access to the system site-packages to make sure PyQt5 can be imported:
+        `pyvenv --system-site-packages trufont`
+    
+4. Activate the newly created environment:
+    - OS X or Linux: `source trufont/bin/activate`
+    - Windows: `trufont\Scripts\activate.bat`
+    (you do `deactivate` to exit the virtual environment)
+
+5. Install dependencies: `pip3 install -r requirements.txt`
+
+6. Install TruFont: `pip3 install .`
+    Or if you wish to edit the source code, install in "editable" mode:
+    `pip3 install -e .` 
+
+7. Run the app as `trufont`.
 
 ## Dependencies
 
@@ -26,23 +50,10 @@ Optional:
 - [extractor, python3-ufo3 branch]
 - [ufo2fdk, python3-ufo3 branch]
 
-## Install notes
-
-- On OSX, it is highly recommended to install all dependencies with [Homebrew]
-  in order to have a correct Qt namespace (`brew` handles it all by itself).  
-  Finish with `brew linkapps python3` to be able to call `python3` from the
-  Terminal.
-- You can have multiple versions of Python on your system, then you just need to
-  use a version prefix, e.g.:
-  * `python3`
-  * `python3.4`
-  * `python3.5`
-  * …
-
 [fontTools]: https://github.com/behdad/fonttools
 [ufoLib]: https://github.com/unified-font-object/ufoLib
 [defcon, python3-ufo3 branch]: https://github.com/trufont/defcon
 [booleanOperations]: https://github.com/trufont/booleanOperations
 [extractor, python3-ufo3 branch]: https://github.com/trufont/extractor
 [ufo2fdk, python3-ufo3 branch]: https://github.com/trufont/ufo2fdk
-[Homebrew]: http://brew.sh/
+

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ PyQt5.
 ## Getting started
 
 1. Install Python 3 
-    - OS X: `brew install python3 && brew linkapps python3`
+    - OS X: Install using [Homebrew]: `brew install python3 && brew linkapps python3`
     - Windows: Download installer from https://www.python.org/downloads/
     - Linux: It's usually packaged with the OS.
 
@@ -56,4 +56,4 @@ Optional:
 [booleanOperations]: https://github.com/trufont/booleanOperations
 [extractor, python3-ufo3 branch]: https://github.com/trufont/extractor
 [ufo2fdk, python3-ufo3 branch]: https://github.com/trufont/ufo2fdk
-
+[Homebrew]: http://brew.sh/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ PyQt5.
         http://pyqt.sourceforge.net/Docs/PyQt5/installation.html
 
 3. Set up a new Python virtual environment using `virtualenv`.
-    - Install or update the virtualenv module with `pip3 install -U virtualenv`.
+    - Install or update the virtualenv module with `pip3 install --upgrade virtualenv`.
+       You may require `sudo` access on Linux. Alternatively, you can install it in
+       the Python user directory: `pip3 install --user --upgrade virtualenv`.
     - Create a new virtual environment, and give it access to the system
         site-packages to make sure PyQt5 can be imported:
         `python3 -m virtualenv --system-site-packages trufont`

--- a/README.md
+++ b/README.md
@@ -19,22 +19,23 @@ PyQt5.
     - Linux: Follow instructions to compile PyQt5 (and SIP) from source:
         http://pyqt.sourceforge.net/Docs/PyQt5/installation.html
 
-3. Set up a new virtual environment using `pyvenv` (or `virtualenv`), and give
-    it access to the system site-packages to make sure PyQt5 can be imported:
-        `pyvenv --system-site-packages trufont`
-    
-4. Activate the newly created environment:
-    - OS X or Linux: `source trufont/bin/activate`
-    - Windows: `trufont\Scripts\activate.bat`
-    (you do `deactivate` to exit the virtual environment)
+3. Set up a new Python virtual environment using `virtualenv`.
+    - Install or update the virtualenv module with `pip3 install -U virtualenv`.
+    - Create a new virtual environment, and give it access to the system
+        site-packages to make sure PyQt5 can be imported:
+        `python3 -m virtualenv --system-site-packages trufont`
+    - Activate the newly created environment:
+        - OS X or Linux: `source trufont/bin/activate`
+        - Windows: `trufont\Scripts\activate.bat`
+    - Run `deactivate` when you wish to exit the virtual environment.
 
-5. Install dependencies: `pip3 install -r requirements.txt`
+4. Install dependencies: `pip3 install -r requirements.txt`
 
-6. Install TruFont: `pip3 install .`
+5. Install TruFont: `pip3 install .`
     Or if you wish to edit the source code, install in "editable" mode:
     `pip3 install -e .` 
 
-7. Run the app as `trufont`.
+6. Run the app as `trufont`.
 
 ## Dependencies
 


### PR DESCRIPTION
I was reading the README.md and I noticed that it says

> run under virtualenv: `cd Lib && python -m defconQt`

That's a bit misleading. The command simply runs trufont in place, it doesn't mean it runs from an isolated virtual environment, as the reference to `virtualenv` seems to imply.

I think it'd be better if we recommend users, and especially developers, to install trufont and its many dependencies inside a virtual environment (a "real" one ;).

Let me know what you think.