### PR TITLE
travis: run tests on OS X instead of Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,12 @@ sudo: false
 language: generic
 os: osx
 before_install:
-  # use pyenv to install python 3.5.1
-  - git clone https://github.com/yyuu/pyenv.git ~/.pyenv
-  - PYENV_ROOT="$HOME/.pyenv"
-  - PATH="$PYENV_ROOT/bin:$PATH"
-  - eval "$(pyenv init -)"
-  - pyenv install 3.5.1
-  - pyenv global 3.5.1
-  - pyenv rehash
-  - python -m pip install --user --upgrade pip virtualenv
+  # use homebrew to install python 3.5.1
+  - brew update || brew update
+  - if test $(brew list | grep -q 'python3'); then brew upgrade python3; else brew install python3; fi
+  - python3.5 -m pip install --user --upgrade pip virtualenv
   # create virtual environment
-  - python -m virtualenv .env
+  - python3.5 -m virtualenv .env
   - source .env/bin/activate
   - python --version
   # install requirements

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,6 @@ before_install:
   - pip install -r requirements.txt
 install:
   - pip install -v .
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
-# commands to run tests
 script:
   - flake8 --config=setup.cfg Lib/trufont
   - py.test -v -r a tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - source .env/bin/activate
   - python --version
   # install requirements
-  - pip install pyqt5 flake8 pytest
+  - pip install pyqt5 cython flake8 pytest
   - python -c "import sip; print(sip.__file__); print('sip version:', sip.SIP_VERSION_STR)"
   - python -c "from PyQt5 import Qt; print(Qt.__file__); print('PyQt5 version:', Qt.PYQT_VERSION_STR)"
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,13 @@ os: osx
 before_install:
   - brew update || brew update
   - if test $(brew list | grep -q 'python3'); then brew upgrade python3; else brew install python3; fi
-  - if test $(brew list | grep -q 'pyqt5'); then brew upgrade pyqt5; else brew install pyqt5; fi
   - python3.5 -m pip install --user --upgrade pip virtualenv
-  - python3.5 -m virtualenv --system-site-packages .env
+  - python3.5 -m virtualenv .env
   - source .env/bin/activate
   - python --version
+  - pip install pyqt5 flake8 pytest
   - python -c "import sip; print(sip.__file__); print('sip version:', sip.SIP_VERSION_STR)"
   - python -c "from PyQt5 import Qt; print(Qt.__file__); print('PyQt5 version:', Qt.PYQT_VERSION_STR)"
-  - pip install flake8 pytest
   - pip install -r requirements.txt
 install:
   - pip install -v .

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,20 @@ sudo: false
 language: generic
 os: osx
 before_install:
-  - brew update || brew update
-  - if test $(brew list | grep -q 'python3'); then brew upgrade python3; else brew install python3; fi
-  - python3.5 -m pip install --user --upgrade pip virtualenv
-  - python3.5 -m virtualenv .env
+  # use pyenv to install python 3.5.1
+  - git clone https://github.com/yyuu/pyenv.git ~/.pyenv
+  - PYENV_ROOT="$HOME/.pyenv"
+  - PATH="$PYENV_ROOT/bin:$PATH"
+  - eval "$(pyenv init -)"
+  - pyenv install 3.5.1
+  - pyenv global 3.5.1
+  - pyenv rehash
+  - python -m pip install --user --upgrade pip virtualenv
+  # create virtual environment
+  - python -m virtualenv .env
   - source .env/bin/activate
   - python --version
+  # install requirements
   - pip install pyqt5 flake8 pytest
   - python -c "import sip; print(sip.__file__); print('sip version:', sip.SIP_VERSION_STR)"
   - python -c "from PyQt5 import Qt; print(Qt.__file__); print('PyQt5 version:', Qt.PYQT_VERSION_STR)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
-# use Ubuntu 14.04LTS trusty
-sudo: required
-dist: trusty
-language: python
+sudo: false
+language: generic
+os: osx
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq -y python3-pyqt5 python3-pip python3-flake8
-  - sudo pip3 install --upgrade setuptools
-  - sudo pip3 install -r requirements.txt
-  - export PYTHONCMD=/usr/bin/python3
+  - brew update || brew update
+  - if test $(brew list | grep -q 'python3'); then brew upgrade python3; else brew install python3; fi
+  - if test $(brew list | grep -q 'pyqt5'); then brew upgrade pyqt5; else brew install pyqt5; fi
+  - python3.5 -m pip install --user --upgrade pip virtualenv
+  - python3.5 -m virtualenv --system-site-packages .env
+  - source .env/bin/activate
+  - python --version
+  - python -c "import sip; print(sip.__file__); print('sip version:', sip.SIP_VERSION_STR)"
+  - python -c "from PyQt5 import Qt; print(Qt.__file__); print('PyQt5 version:', Qt.PYQT_VERSION_STR)"
+  - pip install flake8 pytest
+  - pip install -r requirements.txt
 install:
-  - $PYTHONCMD setup.py install --user
+  - pip install -v .
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
@@ -17,4 +22,4 @@ before_script:
 # commands to run tests
 script:
   - flake8 --config=setup.cfg Lib/trufont
-  - $PYTHONCMD setup.py test
+  - py.test -v -r a tests/


### PR DESCRIPTION
pyqt5 on Ubuntu Trusty is too old; we shall re-enable it once we figure out how to install an updated pyqt5 (>=5.5.1) without having to compile it from source...