### PR TITLE
Use C locale for time/date string saved to UFO

### DIFF
--- a/Lib/trufont/windows/fontInfoWindow.py
+++ b/Lib/trufont/windows/fontInfoWindow.py
@@ -395,8 +395,9 @@ class GeneralTab(TabWidget):
         self.store("versionMajor")
         self.store("versionMinor")
 
-        font.info.openTypeHeadCreated = \
-            self.dateCreatedEdit.dateTime().toString("yyyy/MM/dd hh:mm:ss")
+        font.info.openTypeHeadCreated = QLocale.c().toString(
+                self.dateCreatedEdit.dateTime(),
+                "yyyy/MM/dd hh:mm:ss")
 
         self.store("unitsPerEm")
         self.store("italicAngle")


### PR DESCRIPTION
Otherwise we get locale-specific strings which can be invalid for UFO
format.