### PR TITLE
Draw icons in Hi-DPI mode

### DIFF
--- a/Lib/trufont/__main__.py
+++ b/Lib/trufont/__main__.py
@@ -4,7 +4,7 @@ from trufont.objects.application import Application
 from trufont.resources import icons_db  # noqa
 from trufont.windows.outputWindow import OutputWindow
 from PyQt5.QtCore import (
-    QCommandLineParser, QSettings, QTranslator, QLocale, QLibraryInfo)
+    Qt, QCommandLineParser, QSettings, QTranslator, QLocale, QLibraryInfo)
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QApplication, QMessageBox
 import os
@@ -26,6 +26,7 @@ def main():
     app.setApplicationName("TruFont")
     app.setApplicationVersion(__version__)
     app.setWindowIcon(QIcon(":app.png"))
+    app.setAttribute(Qt.AA_UseHighDpiPixmaps, True)
 
     # Install stream redirection
     app.outputWindow = OutputWindow()


### PR DESCRIPTION
Set the AA_UseHighDpiPixmaps so that Qt returns larger pixmaps for
Hi-DPI systems.

Before:
![2016-04-30 06-45-54](https://cloud.githubusercontent.com/assets/93914/14933912/ad09f984-0ea7-11e6-93d1-bffdb3a295e6.png)

After:
![2016-04-30 06-46-21](https://cloud.githubusercontent.com/assets/93914/14933913/b4dc191c-0ea7-11e6-8212-edced213dc8b.png)

