### PR TITLE
Set AA_EnableHighDpiScaling attribute to QApplication

### DIFF
--- a/Lib/trufont/__main__.py
+++ b/Lib/trufont/__main__.py
@@ -19,6 +19,8 @@ def main():
     # register representation factories
     baseRepresentationFactories.registerAllFactories()
     representationFactories.registerAllFactories()
+    if hasattr(Qt, "AA_EnableHighDpiScaling"):
+        QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
     # initialize the app
     app = Application(sys.argv)
     app.setOrganizationName("TruFont")


### PR DESCRIPTION
Enables Hi-DPI scaling ion X11 without the need to set an environment
variable.