### PR TITLE
Select anchors and components with “Select All”

### DIFF
--- a/Lib/trufont/windows/glyphWindow.py
+++ b/Lib/trufont/windows/glyphWindow.py
@@ -228,9 +228,10 @@ class GlyphWindow(BaseMainWindow):
     def selectAll(self):
         glyph = self.view.glyph()
         glyph.selected = True
-        if not len(glyph):
-            for component in glyph.components:
-                component.selected = True
+        for component in glyph.components:
+            component.selected = True
+        for anchor in glyph.anchors:
+            anchor.selected = True
 
     def deselect(self):
         glyph = self.view.glyph()


### PR DESCRIPTION
Currently it does not select anchors at all, and selects components only
when the glyph has no contours.