### PR TITLE
glyphWindow: glyphOffset() should skip glyphs in glyphOrder but not in font

### DIFF
--- a/Lib/trufont/windows/glyphWindow.py
+++ b/Lib/trufont/windows/glyphWindow.py
@@ -146,7 +146,13 @@ class GlyphWindow(BaseMainWindow):
         if not (glyphOrder and len(glyphOrder)):
             return
         index = glyphOrder.index(currentGlyph.name)
-        newIndex = (index + offset) % len(glyphOrder)
+        newIndex = index
+        sign = offset//abs(offset)
+        while True:
+            newIndex = newIndex + sign
+            newIndex = (newIndex) % len(glyphOrder)
+            if glyphOrder[newIndex] in font:
+                break
         glyph = font[glyphOrder[newIndex]]
         self.setGlyph(glyph)
 


### PR DESCRIPTION
In glyphWindow, Next Glyph or Previous Glyph may raise KeyError when a glyphOrder has glyphs not in a font.