### PR TITLE
Store absolute path of recent file

### DIFF
--- a/Lib/trufont/windows/fontWindow.py
+++ b/Lib/trufont/windows/fontWindow.py
@@ -642,6 +642,7 @@ class FontWindow(BaseMainWindow):
     def setCurrentFile(self, path):
         if path is None:
             return
+        path = os.path.abspath(path)
         recentFiles = settings.recentFiles()
         if path in recentFiles:
             recentFiles.remove(path)


### PR DESCRIPTION
Otherwise loading a font from the recent files menu that was opened using
a relative path will fail when switching to a different directory.