### PR TITLE
Always show glyph name in the glyph tab title

### DIFF
--- a/Lib/trufont/windows/fontWindow.py
+++ b/Lib/trufont/windows/fontWindow.py
@@ -45,9 +45,13 @@ _path.closeSubpath()
 
 
 def _textForGlyphs(glyphs):
-    return "".join(
-        chr(glyph.unicode) if glyph.unicode is not None else
-        "/{} ".format(glyph.name) for glyph in glyphs)
+    names = []
+    for glyph in glyphs:
+        char = ""
+        if glyph.unicode and chr(glyph.unicode) != glyph.name:
+            char = " ({})".format(chr(glyph.unicode))
+        names.append("/{}{}".format(glyph.name, char))
+    return " ".join(names)
 
 
 class PageWidget(QWidget):


### PR DESCRIPTION
If the glyph character (from the unicode value) is different than the
glyph name, show it in parenthesis as well.

Fixes https://github.com/trufont/trufont/issues/387.