### PR TITLE
[drawingTools] add a simple Hand tool to pan glyph canvas view

### DIFF
--- a/Lib/trufont/controls/glyphCanvasView.py
+++ b/Lib/trufont/controls/glyphCanvasView.py
@@ -450,8 +450,6 @@ class GlyphCanvasView(GlyphContextView):
         return True
 
     def _redirectEvent(self, event, callback, transmute=False):
-        if self._preview:
-            return
         # construct a new event with pos in canvas coordinates
         if transmute:
             if isinstance(event, QContextMenuEvent):

--- a/Lib/trufont/controls/toolBar.py
+++ b/Lib/trufont/controls/toolBar.py
@@ -2,6 +2,7 @@ from PyQt5.QtCore import pyqtSignal, QSize
 from PyQt5.QtGui import QColor, QKeySequence, QPainter
 from PyQt5.QtWidgets import QSizePolicy, QVBoxLayout, QWidget
 from trufont.controls.pathButton import PathButton
+from trufont.drawingTools.handTool import HandTool
 
 
 class ToolBar(QWidget):
@@ -117,3 +118,10 @@ class ToolBar(QWidget):
     def paintEvent(self, event):
         painter = QPainter(self)
         painter.fillRect(event.rect(), QColor(240, 240, 240))
+
+    def handTool(self):
+        if not hasattr(self, '_handTool'):
+            for tool in self._tools:
+                if isinstance(tool, HandTool):
+                    self._handTool = tool
+        return self._handTool

--- a/Lib/trufont/drawingTools/handTool.py
+++ b/Lib/trufont/drawingTools/handTool.py
@@ -40,6 +40,12 @@ class HandTool(BaseTool):
     name = QApplication.translate("HandTool", "Hand")
     shortcut = "H"
 
+    def toolActivated(self):
+        self.parent().setPreviewEnabled(True)
+
+    def toolDisabled(self):
+        self.parent().setPreviewEnabled(False)
+
     def mousePressEvent(self, event):
         if event.button() == Qt.LeftButton:
             widget = self.parent()

--- a/Lib/trufont/drawingTools/handTool.py
+++ b/Lib/trufont/drawingTools/handTool.py
@@ -1,0 +1,63 @@
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QPainterPath
+from PyQt5.QtWidgets import QApplication
+from trufont.drawingTools.baseTool import BaseTool
+
+
+_path = QPainterPath()
+_path.moveTo(12.5, 22.6)
+_path.lineTo(16.3, 18.5)
+_path.lineTo(15.7, 17.9)
+_path.lineTo(10.3, 23.8)
+_path.cubicTo(9.8, 24.4, 9.1, 24.4, 8.7, 24.1)
+_path.cubicTo(8.1, 23.6, 8.2, 23, 8.7, 22.4)
+_path.lineTo(13.7, 17.2)
+_path.lineTo(13, 16.5)
+_path.lineTo(7.3, 22.5)
+_path.cubicTo(6.8, 23.1, 6.2, 23.2, 5.7, 22.7)
+_path.cubicTo(5.1, 22.3, 5.2, 21.6, 5.6, 21.1)
+_path.lineTo(11.6, 14.8)
+_path.lineTo(10.9, 14.1)
+_path.lineTo(6.2, 19.1)
+_path.cubicTo(5.7, 19.6, 5.1, 19.8, 4.5, 19.3)
+_path.cubicTo(4, 18.8, 4, 18.1, 4.5, 17.5)
+_path.lineTo(11.2, 10.3)
+_path.lineTo(7.9, 10.9)
+_path.cubicTo(6.9, 11, 6.4, 10.7, 6.3, 10.1)
+_path.cubicTo(6, 9.3, 6.7, 8.7, 7.6, 8.1)
+_path.cubicTo(9.3, 7.2, 12.6, 6, 14.3, 5.7)
+_path.cubicTo(16.7, 5.2, 19, 5.7, 21.1, 7.6)
+_path.cubicTo(23.7, 10, 24, 13.5, 21.5, 16.1)
+_path.lineTo(14.2, 24.1)
+_path.cubicTo(13.8, 24.6, 13, 24.8, 12.4, 24.2)
+_path.cubicTo(12, 23.8, 12, 23, 12.5, 22.6)
+_path.closeSubpath()
+
+
+class HandTool(BaseTool):
+
+    icon = _path
+    name = QApplication.translate("HandTool", "Hand")
+    shortcut = "H"
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton:
+            widget = self.parent()
+            widget.setCursor(Qt.ClosedHandCursor)
+            self._panOrigin = event.globalPos()
+
+    def mouseMoveEvent(self, event):
+        if hasattr(self, "_panOrigin"):
+            pos = event.globalPos()
+            self.parent().scrollBy(pos - self._panOrigin)
+            self._panOrigin = pos
+
+    def mouseReleaseEvent(self, event):
+        widget = self.parent()
+        widget.setCursor(Qt.OpenHandCursor)
+        if hasattr(self, "_panOrigin"):
+            del self._panOrigin
+
+    @property
+    def cursor(self):
+        return Qt.OpenHandCursor

--- a/Lib/trufont/objects/application.py
+++ b/Lib/trufont/objects/application.py
@@ -8,6 +8,7 @@ from trufont.drawingTools.penTool import PenTool
 from trufont.drawingTools.rulerTool import RulerTool
 from trufont.drawingTools.knifeTool import KnifeTool
 from trufont.drawingTools.textTool import TextTool
+from trufont.drawingTools.handTool import HandTool
 from trufont.windows.fontWindow import FontWindow
 from trufont.windows.extensionBuilderWindow import ExtensionBuilderWindow
 from trufont.windows.scriptingWindow import ScriptingWindow
@@ -29,7 +30,7 @@ class Application(QApplication):
         self._currentFontWindow = None
         self._launched = False
         self._drawingTools = [
-            SelectionTool, PenTool, KnifeTool, RulerTool, TextTool]
+            SelectionTool, PenTool, KnifeTool, RulerTool, HandTool, TextTool]
         self._extensions = []
         self.dispatcher = NotificationCenter()
         self.dispatcher.addObserver(self, "_fontWindowClosed", "fontWillClose")

--- a/Lib/trufont/windows/fontWindow.py
+++ b/Lib/trufont/windows/fontWindow.py
@@ -78,10 +78,10 @@ class PreviewEventFilter(QObject):
             return False
         # or should we reset on WindowActivate?
         if event.type() == QEvent.WindowDeactivate:
-            self.parent()._setGlyphPreview(False)
+            self.parent()._toggleHandTool(False)
         if event.type() in self.filterKeyEvents:
             if not event.isAutoRepeat() and event.key() == Qt.Key_Space:
-                self.parent()._setGlyphPreview(
+                self.parent()._toggleHandTool(
                     event.type() != QEvent.KeyRelease)
                 event.accept()
                 return True
@@ -975,11 +975,21 @@ class FontWindow(BaseWindow):
 
     # update methods
 
-    def _setGlyphPreview(self, value):
+    def _toggleHandTool(self, value):
         index = self.stackWidget.currentIndex()
         if index:
             widget = self.stackWidget.currentWidget()
-            widget.setPreviewEnabled(value)
+            currentWidgetTool = widget.currentTool()
+            if value:
+                # enable both hand tool and preview mode on space key pressed
+                handTool = self.toolBar.handTool()
+                if currentWidgetTool != handTool:
+                    widget.setCurrentTool(handTool)
+            else:
+                # disable preview and restore previous tool on space key raised
+                previousTool = self.toolBar.currentTool()
+                if currentWidgetTool != previousTool:
+                    widget.setCurrentTool(previousTool)
 
     def _updateCurrentGlyph(self):
         # TODO: refactor this pattern...


### PR DESCRIPTION
This is my first experiment hacking with PyQt5 and the TruFont GUI, so please be kind ;)

It's somewhat related to https://github.com/trufont/trufont/issues/275

I thought we could make the space key toggle on/off this hand tool, so that we could support the filled-in preview combined with panning of the canvas on dragging the cursor (like Glyphs and Robofont do).