### PR TITLE
[selectionTool] fix IndexError when dragging last offcurve in contour...

### DIFF
--- a/Lib/trufont/drawingTools/selectionTool.py
+++ b/Lib/trufont/drawingTools/selectionTool.py
@@ -428,7 +428,7 @@ class SelectionTool(BaseTool):
                         p_ = c[i]
                         if p_.segmentType is None:
                             for d in (-1, 1):
-                                p__ = c[i+d]
+                                p__ = c[(i+d) % len(c)]
                                 if p__.segmentType is not None:
                                     canvasPos = self.clampToOrigin(
                                         canvasPos, QPointF(p__.x, p__.y))

--- a/Lib/trufont/drawingTools/selectionTool.py
+++ b/Lib/trufont/drawingTools/selectionTool.py
@@ -428,7 +428,7 @@ class SelectionTool(BaseTool):
                         p_ = c[i]
                         if p_.segmentType is None:
                             for d in (-1, 1):
-                                p__ = c[(i+d) % len(c)]
+                                p__ = c.getPoint((i+d))
                                 if p__.segmentType is not None:
                                     canvasPos = self.clampToOrigin(
                                         canvasPos, QPointF(p__.x, p__.y))


### PR DESCRIPTION
...  while SHIFT is pressed.

We need to modulo the index when getting next/previous points in contour, else this happens:

```
Traceback (most recent call last):
  File "trufont/Lib/trufont/controls/glyphCanvasView.py", line 404, in mouseMoveEvent
    self._redirectEvent(event, self._currentTool.mouseMoveEvent, True)
  File "trufont/Lib/trufont/controls/glyphCanvasView.py", line 499, in _redirectEvent
    callback(event)
  File "trufont/Lib/trufont/drawingTools/selectionTool.py", line 431, in mouseMoveEvent
    p__ = c[i+d]
  File "/usr/local/var/pyenv/versions/3.6.1/envs/trufont361/lib/python3.6/site-packages/defcon/objects/contour.py", line 229, in __getitem__
    return self._points.__getitem__(index)
IndexError: list index out of range
```