### PR TITLE
Fix clearing recent files list

### DIFF
--- a/Lib/trufont/objects/settings.py
+++ b/Lib/trufont/objects/settings.py
@@ -347,7 +347,7 @@ def setLoadRecentFile(value):
 
 
 def recentFiles():
-    return value("core/recentFiles", [], type=str)
+    return value("core/recentFiles", [], type=list)
 
 
 def setRecentFiles(recentFiles):


### PR DESCRIPTION
Clearing the list would work, but upon constructing a new one, the type
of the empty list was set to "str" instead of "list", which resulted in
an exception when loading a new font tried to insert that font into the
recent files list.

Fixes bug #399.