### PR TITLE
Make repeat sorting with the same sort descriptor possible.

### DIFF
--- a/Lib/trufont/objects/defcon.py
+++ b/Lib/trufont/objects/defcon.py
@@ -170,8 +170,6 @@ class TFont(Font):
 
     def _set_sortDescriptor(self, value):
         oldValue = self.lib.get("com.typesupply.defcon.sortDescriptor")
-        if oldValue == value:
-            return
         if value is None or len(value) == 0:
             value = None
             if "com.typesupply.defcon.sortDescriptor" in self.lib:


### PR DESCRIPTION
Before, _set_sortDescriptor() checked if the new value was equal to the
old one and if so, returned early. This made it impossible to repeatedly
sort using the same descriptor, e.g. after having repeatedly added
glyphs without the sorting option in the "Add glyphs" dialog.

Fixes #430.