### PR TITLE
Do not try to update the selection label if selection is [None].

### DIFF
--- a/Lib/trufont/windows/fontWindow.py
+++ b/Lib/trufont/windows/fontWindow.py
@@ -479,7 +479,7 @@ class FontWindow(BaseWindow):
             # selection text
             # TODO: this should probably be internal to the label
             selection = self.glyphCellView.selection()
-            if selection is not None:
+            if selection is not None and None not in selection:
                 count = len(selection)
                 if count == 1:
                     glyph = self.glyphCellView.glyphsForIndexes(selection)[0]


### PR DESCRIPTION
Before, the code in FontWindow._selectionChanged() checked for selection
to not be None, but didn't check if it actually was [None]. The user
could trigger an uncaught exception if e.g. he modified some glyph, went
back to the font view, clicked on empty space to deselect all glyphs and
then saved.

Together with the defoncQt PR, this fixes #429 in my quick testing.