### PR TITLE
Handle sort_descriptor == None in FontWindow._sortDescriptorChanged()

### DIFF
--- a/Lib/trufont/windows/fontWindow.py
+++ b/Lib/trufont/windows/fontWindow.py
@@ -538,6 +538,8 @@ class FontWindow(BaseWindow):
     def _sortDescriptorChanged(self, notification):
         font = notification.object
         descriptors = notification.data["newValue"]
+        if descriptors is None:
+            return
         if descriptors[0]["type"] == "glyphSet":
             glyphNames = descriptors[0]["glyphs"]
         else:


### PR DESCRIPTION
When adding glyphs and checking "Sort font" without having set a sort
descriptor in the "Sort" dialog first, an unhandled exception is thrown
by FontWindow._sortDescriptorChanged(). Return early on None.

Fixes bug #455.

The fix is not ideal (open sort dialog instead?), but better than an exception.