### PR TITLE
Revert "application: fix menu switch"

### DIFF
--- a/Lib/trufont/objects/application.py
+++ b/Lib/trufont/objects/application.py
@@ -42,14 +42,10 @@ class Application(QApplication):
     # --------------
 
     def _focusWindowChanged(self):
-        window = self.activeWindow()
-        # trash unwanted calls
-        if hasattr(self, "_focusWindow") and window == self._focusWindow:
-            return
-        self._focusWindow = window
         # update menu bar
         self.updateMenuBar()
         # update main window
+        window = self.activeWindow()
         if window is None:
             return
         while True:


### PR DESCRIPTION
This reverts commit 0d6862ff29effc2e70df22223ef40c17a37c8f24.

The original bug can no longer be reproduced (see #333); additionally,
the workaround caused #423. Saving the last window with focus caused
random crashes on Linux when certain dialogs were closed, an issue with
object lifetimes may be involved.