### PR TITLE
Fix Extension Builder window

### DIFF
--- a/Lib/trufont/objects/extension.py
+++ b/Lib/trufont/objects/extension.py
@@ -162,7 +162,7 @@ class TExtension(object):
         writer.writeLib(libPath)
         writer.writeInfo(self._info)
         writer.writeResources(
-            os.path.join(self._path, self._resourcesPath or RESOURCES_PATH))
+            os.path.join(path, self._resourcesPath or RESOURCES_PATH))
         # done
         self._path = path
 

--- a/Lib/trufont/objects/extension.py
+++ b/Lib/trufont/objects/extension.py
@@ -198,15 +198,15 @@ class TExtension(object):
         # TODO: should it e.g. look if the mainScript is an actual Python file
         raise NotImplementedError
 
-    def run(self, subpath=None):
+    def run(self, subPath=None):
         libPath = self._libPath
         if libPath is None:
             libPath = LIB_PATH
-        if subpath is None:
+        if subPath is None:
             subPath = self.mainScript
             if subPath is None:
                 subPath = ""
-        runPath = os.path.join(self._path, libPath, subpath)
+        runPath = os.path.join(self._path, libPath, subPath)
         app = QApplication.instance()
         global_vars = app.globals()
         try:

--- a/Lib/trufont/objects/extension.py
+++ b/Lib/trufont/objects/extension.py
@@ -364,9 +364,20 @@ class Version(str):
 
 
 def _stringToSequence(value):
-    major, minor, patch = [i.strip() for i in value.split(".")]
+    value = [i.strip() for i in value.split(".", 3)]
+    if len(value) < 3:
+        # Pad
+        value.extend(["0"] * (3 - len(value)))
+    else:
+        # Trim
+        value = value[:3]
+
+    major, minor, patch = value
     value = []
     for component in (major, minor, patch):
-        v = int(component)
+        try:
+            v = int(component)
+        except ValueError:
+            v = 0
         value.append(v)
     return value

--- a/Lib/trufont/objects/extension.py
+++ b/Lib/trufont/objects/extension.py
@@ -339,7 +339,7 @@ class Version(str):
 
     def __new__(self, value):
         # convert from sequence
-        if isinstance(value, Sequence):
+        if isinstance(value, Sequence) and not isinstance(value, str):
             assert len(value) == 3
             value = ".".join(str(num) for num in value)
         return super().__new__(Version, value)

--- a/Lib/trufont/windows/extensionBuilderWindow.py
+++ b/Lib/trufont/windows/extensionBuilderWindow.py
@@ -99,7 +99,7 @@ class ExtensionBuilderWindow(QDialog):
             if not ok:
                 continue
             data = dict(path=path, name=name, shortcut=shortcut)
-            for k, v in data.items():
+            for k, v in list(data.items()):
                 if v is None:
                     del data[k]
             addToMenu.append(data)


### PR DESCRIPTION
This dialog is extremely unusable, whatever I do will result in assert or error somewhere! With these fixes I can finally build an extension and register a menu item (though I’m yet to get that menu item to do anything, but that is a different issue).