### PR TITLE
layoutEngine: Guard harder against feaLib failures

### DIFF
--- a/Lib/trufont/objects/layoutEngine.py
+++ b/Lib/trufont/objects/layoutEngine.py
@@ -24,9 +24,9 @@ def _layoutEngineOTLTablesRepresentationFactory(layoutEngine):
     if font.features.text:
         otf = TTFont()
         otf.setGlyphOrder(glyphOrder)
-        # compile with feaLib + markWriter. kerning is handled separately
+        # compile with feaLib + markWriter/kernWriter
         try:
-            compiler = FeatureCompiler(font, otf, kernWriterClass=None)
+            compiler = FeatureCompiler(font, otf)
             compiler.postProcess = lambda: None
             compiler.compile()
             for name in ("GDEF", "GSUB", "GPOS"):
@@ -127,7 +127,6 @@ class LayoutEngine(BaseObject):
         funcs.set_nominal_glyph_func(_get_nominal_glyph, None, None)
         funcs.set_glyph_h_advance_func(_get_glyph_h_advance, None, None)
         # TODO: vertical advance
-        # TODO: kerning funcs from UFO kerning?
         funcs.set_glyph_name_func(_get_glyph_name_func, None, None)
         font.set_funcs(funcs, self, None)
 

--- a/Lib/trufont/objects/layoutEngine.py
+++ b/Lib/trufont/objects/layoutEngine.py
@@ -39,6 +39,8 @@ def _layoutEngineOTLTablesRepresentationFactory(layoutEngine):
             # TODO: handle this in the UI
             import traceback
             print(traceback.format_exc(5))
+            # discard tables from incompletely parsed feature text
+            ret = dict()
     return ret, glyphOrder
 
 # harfbuzz

--- a/Lib/trufont/objects/layoutEngine.py
+++ b/Lib/trufont/objects/layoutEngine.py
@@ -29,17 +29,16 @@ def _layoutEngineOTLTablesRepresentationFactory(layoutEngine):
             compiler = FeatureCompiler(font, otf, kernWriterClass=None)
             compiler.postProcess = lambda: None
             compiler.compile()
-        except:
-            # TODO: handle this in the UI
-            import traceback
-            print(traceback.format_exc(5))
-        else:
             for name in ("GDEF", "GSUB", "GPOS"):
                 if name in otf:
                     table = otf[name].compile(otf)
                     value = hb.Blob.create_for_array(
                         table, HB.MEMORY_MODE_READONLY)
                     ret[name] = value
+        except:
+            # TODO: handle this in the UI
+            import traceback
+            print(traceback.format_exc(5))
     return ret, glyphOrder
 
 # harfbuzz


### PR DESCRIPTION
Apparently feaLib will happily compile feature text using non-existent
glyphs, but compiling the table will obviously fail, so the compilation
step needs to be inside the try statement as well.

Without this change editing any glyphs in Reem Kufi source UFO will fail
as there are missing glyphs referenced by the feature code (they are
added at build time by the build script).