### PR TITLE
Fix "TypeError: newGlyph() missing 1 required positional argument"

### DIFF
--- a/Lib/trufont/objects/defcon.py
+++ b/Lib/trufont/objects/defcon.py
@@ -9,6 +9,7 @@ from trufont.objects.undoManager import UndoManager
 from ufo2ft import compileOTF, compileTTF
 import fontTools
 import math
+import types
 
 _shaper = True
 try:
@@ -100,12 +101,14 @@ class TFont(Font):
         app.postNotification("fontWillExtract", data)
         # don't bring on UndoManager just yet
         func = self.newGlyph
-        self.newGlyph = Font.newGlyph
-        extractor.extractUFO(path, self, fileFormat)
-        for glyph in self:
-            glyph.dirty = False
-            glyph.undoManager = UndoManager(glyph)
-        self.newGlyph = func
+        try:
+            self.newGlyph = types.MethodType(Font.newGlyph, self)
+            extractor.extractUFO(path, self, fileFormat)
+            for glyph in self:
+                glyph.dirty = False
+                glyph.undoManager = UndoManager(glyph)
+        finally:
+            self.newGlyph = func
         self.dirty = False
         self._binaryPath = path
 


### PR DESCRIPTION
After this commit 3df77f720b7f2bcfe01eaf4112b36b8bcb3f8462, I am seeing this error every time I try to import an OTF or TTF, which uses extractor.

The reason is we can't just assign `Font.newGlyph`, which is a class attribute, and thus an "unbound" method, to an instance as self.newGlyph.

In order to dynamically "bind" a method to an instance, we can use `types.MethodType`.

https://docs.python.org/3/library/types.html

Also, the original newGlyph method is restored with a try/finally block, in case anything goes wrong during the extraction.