### PR TITLE
Export SVG to the clipboard as well

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyqt5==5.9
-fonttools==3.16.0
+fonttools==3.17.0
 ufoLib==2.1.0
 defcon==0.3.5
 defconQt==0.5.4

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     },
     install_requires=[
         "pyqt5>=5.5.0",
-        "fonttools>=3.13.1",
+        "fonttools>=3.17.0",
         "ufoLib>=2.1.0",
         "defcon>=0.3.4",
         "defconQt>=0.5.3",


### PR DESCRIPTION
This way one can copy glyphs from TruFont and paste them into Inkscape. We might want to support other vector formats for popular vector graphics editors.