### PR TITLE
Fix error on opening a new file when recent files is none

### DIFF
--- a/Lib/trufont/objects/application.py
+++ b/Lib/trufont/objects/application.py
@@ -586,7 +586,7 @@ class Application(QApplication):
         if path is None:
             return
         path = os.path.abspath(path)
-        recentFiles = settings.recentFiles()
+        recentFiles = settings.recentFiles() or []
         if path in recentFiles:
             recentFiles.remove(path)
         recentFiles.insert(0, path)


### PR DESCRIPTION
Application throws error when recent files is none. Add default
value as an empty array.

Example trace:
```
Traceback (most recent call last):
  File "/home/santhosh/work/fonts/tools/trufont/Lib/trufont/objects/menu.py", line 85, in <lambda>
    action.triggered.connect(lambda: callback())
  File "/home/santhosh/work/fonts/tools/trufont/Lib/trufont/objects/application.py", line 375, in openFile
    self._openFile(path, importFile=platformSpecific.mergeOpenAndImport())
  File "/home/santhosh/work/fonts/tools/trufont/Lib/trufont/objects/application.py", line 446, in _openFile
    self._loadUFO(path)
  File "/home/santhosh/work/fonts/tools/trufont/Lib/trufont/objects/application.py", line 489, in _loadUFO
    self.setCurrentFile(font.path)
  File "/home/santhosh/work/fonts/tools/trufont/Lib/trufont/objects/application.py", line 592, in setCurrentFile
    recentFiles.insert(0, path)
AttributeError: 'str' object has no attribute 'insert'
```