### PR TITLE
Allow editing anchor coordinates on double click

### DIFF
--- a/Lib/trufont/controls/glyphDialogs.py
+++ b/Lib/trufont/controls/glyphDialogs.py
@@ -1,4 +1,5 @@
-from PyQt5.QtCore import QEvent, Qt
+from PyQt5.QtCore import QEvent, QLocale, Qt
+from PyQt5.QtGui import QDoubleValidator
 from PyQt5.QtWidgets import (
     QDialog, QDialogButtonBox, QGridLayout, QLabel, QLineEdit, QListWidget,
     QRadioButton)
@@ -162,16 +163,25 @@ class LayerActionsDialog(QDialog):
         return (newLayer, action, result)
 
 
-class RenameDialog(QDialog):
+class EditDialog(QDialog):
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, item=None):
         super().__init__(parent)
         self.setWindowModality(Qt.WindowModal)
-        self.setWindowTitle(self.tr("Rename…"))
+        self.setWindowTitle(self.tr("Edit…"))
 
         nameLabel = QLabel(self.tr("Name:"), self)
         self.nameEdit = QLineEdit(self)
         self.nameEdit.setFocus(Qt.OtherFocusReason)
+
+        validator = QDoubleValidator(self)
+        validator.setLocale(QLocale.c())
+        xLabel = QLabel(self.tr("X:"), self)
+        self.xEdit = QLineEdit(self)
+        self.xEdit.setValidator(validator)
+        yLabel = QLabel(self.tr("Y:"), self)
+        self.yEdit = QLineEdit(self)
+        self.yEdit.setValidator(validator)
 
         buttonBox = QDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
@@ -183,14 +193,25 @@ class RenameDialog(QDialog):
         layout.addWidget(nameLabel, l, 0)
         layout.addWidget(self.nameEdit, l, 1, 1, 3)
         l += 1
+        layout.addWidget(xLabel, l, 0)
+        layout.addWidget(self.xEdit, l, 1)
+        layout.addWidget(yLabel, l, 2)
+        layout.addWidget(self.yEdit, l, 3)
+        l += 1
         layout.addWidget(buttonBox, l, 3)
         self.setLayout(layout)
 
     @classmethod
-    def getNewName(cls, parent, name=None):
-        dialog = cls(parent)
-        dialog.nameEdit.setText(name)
+    def getNewProperties(cls, parent, item):
+        dialog = cls(parent, item)
+        dialog.nameEdit.setText(item.name)
         dialog.nameEdit.selectAll()
+        dialog.xEdit.setText(str(item.x))
+        dialog.xEdit.selectAll()
+        dialog.yEdit.setText(str(item.y))
+        dialog.yEdit.selectAll()
         result = dialog.exec_()
         name = dialog.nameEdit.text()
-        return (name, result)
+        x = float(dialog.xEdit.text())
+        y = float(dialog.yEdit.text())
+        return (name, x, y, result)

--- a/Lib/trufont/drawingTools/selectionTool.py
+++ b/Lib/trufont/drawingTools/selectionTool.py
@@ -4,7 +4,7 @@ from PyQt5.QtWidgets import (
     QMenu, QRubberBand, QStyle, QStyleOptionRubberBand, QApplication)
 from defcon import Anchor, Component, Glyph, Guideline
 from fontTools.pens.basePen import decomposeQuadraticSegment
-from trufont.controls.glyphDialogs import AddComponentDialog, RenameDialog
+from trufont.controls.glyphDialogs import AddComponentDialog, EditDialog
 from trufont.drawingTools.baseTool import BaseTool
 from trufont.tools import bezierMath, platformSpecific
 from trufont.tools.uiMethods import (
@@ -254,11 +254,13 @@ class SelectionTool(BaseTool):
                 dy *= 10
         return (dx, dy)
 
-    def _renameItem(self, item):
+    def _editItem(self, item):
         widget = self.parent()
-        newName, ok = RenameDialog.getNewName(widget, item.name)
+        newName, x, y, ok = EditDialog.getNewProperties(widget, item)
         if ok:
             item.name = newName
+            item.x = x
+            item.y = y
 
     def _reverse(self, target=None):
         if target is None:
@@ -503,7 +505,7 @@ class SelectionTool(BaseTool):
                     # if we have one offCurve, make it tangent
                     maybeProjectUISmoothPointOffcurve(contour, index)
             elif isinstance(item, (Anchor, Guideline)):
-                self._renameItem(item)
+                self._editItem(item)
         else:
             if self._performSegmentClick(event.localPos(), "selectContour"):
                 return

--- a/Lib/trufont/drawingTools/selectionTool.py
+++ b/Lib/trufont/drawingTools/selectionTool.py
@@ -79,6 +79,7 @@ class SelectionTool(BaseTool):
         # add one at position
         anchor = dict(x=pos.x(), y=pos.y(), name="new anchor")
         glyph.appendAnchor(anchor)
+        self._editItem(glyph.anchors[-1])
 
     def _createComponent(self, *_):
         widget = self.parent()


### PR DESCRIPTION
Adjusting the exact position of an anchor is often needed, and without
this patch I find myself opening the glif files in a text editor to edit
the anchors.