### PR TITLE
Support drag and dropping .glif files to glyph canvas

### DIFF
--- a/Lib/trufont/controls/glyphCanvasView.py
+++ b/Lib/trufont/controls/glyphCanvasView.py
@@ -306,7 +306,8 @@ class GlyphCanvasView(GlyphContextView):
             if url.isLocalFile():
                 path = url.toLocalFile()
                 ext = os.path.splitext(path)[1][1:]
-                if ext.lower() in QImageReader.supportedImageFormats() + ['glif']:
+                formats = QImageReader.supportedImageFormats() + ['glif']
+                if ext.lower() in formats:
                     event.acceptProposedAction()
             return
         super().dragEnterEvent(event)


### PR DESCRIPTION
Helpful for using glif files created from svg for example.

If the glyph has components, and they should pre-exist in UFO.
  