### PR TITLE
Update ufoLib-2.1.0 to ufoLib-2.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pyqt5==5.9
 fonttools==3.17.0
-ufoLib==2.1.0
+ufoLib==2.1.1
 defcon==0.3.5
 defconQt==0.5.4
 ufo-extractor==0.2.0


### PR DESCRIPTION
Fixes issue #537

TruFont won't run for me on Arch and Ubuntu unless ufoLib-2.1.1 is installed, changing ufoLib==2.1.0 to ufoLib==2.1.1 in requirements.txt fixes the problem.