### PR TITLE
WX: Handle quadratic curves

### DIFF
--- a/src/trufont/objects/factories.py
+++ b/src/trufont/objects/factories.py
@@ -97,6 +97,17 @@ def pathGraphicsPathFactory(path):
             if point.type == "curve":
                 graphicsPath.AddCurveToPoint(*stack)
                 stack = []
+            elif point.type == "qcurve":
+                if len(stack) == 4:
+                    graphicsPath.AddQuadCurveToPoint(*stack)
+                else:
+                    for offset in range(0, len(stack) - 4, 2):
+                        cx1, cy1, cx2, cy2 = stack[offset : offset + 4]
+                        graphicsPath.AddQuadCurveToPoint(
+                            cx1, cy1, (cx1 + cx2) / 2, (cy1 + cy2) / 2
+                        )
+                    graphicsPath.AddQuadCurveToPoint(*stack[-4:])
+                stack = []
     if not open_:
         graphicsPath.CloseSubpath()
     return graphicsPath


### PR DESCRIPTION
Fixes https://github.com/trufont/trufont/issues/598.

http://unifiedfontobject.org/versions/ufo3/glyphs/glif/#contour says a contour only containing off-curves must be treated as quadratic. Still need to implement that.

Also: more resilience to invalid curves like 3 off-curves and a `curve`? Ideally, this is caught and the UI displays the glyph as containing invalid contours, allowing the user to go in and fix it...