### PR TITLE
Update requirements to use latest dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-pyqt5==5.9
-fonttools==3.17.0
-ufoLib==2.1.1
-defcon==0.3.5
+pyqt5==5.12
+fonttools[unicode,ufo]==3.38
+ufoLib==2.3.2
+defcon==0.6.0
 defconQt==0.5.4
 ufo-extractor==0.2.0
-ufo2ft==0.6.2
-booleanOperations==0.7.1
+ufo2ft==2.7.0
+booleanOperations==0.8.2
 hsluv==0.0.2
-brotli==0.6.0
+brotli==1.0.7


### PR DESCRIPTION
I know the main work is being done at wx branch. But to make the master branch usable, it is must to udpate the dependencies. 

Addresses #623 too.

This makes the master version usable by cloning the repo, `pip install -r requirements.txt` and then `pip install -e .`