### PR TITLE
Depend on new ufo-extractor, update rest of deps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/ambv/black
-  rev: 19.3b0
+  rev: 19.10b0
   hooks:
   - id: black
     language_version: python3
@@ -10,12 +10,12 @@ repos:
   - id: blacken-docs
     additional_dependencies: [black==19.3b0]
 - repo: https://github.com/asottile/pyupgrade
-  rev: v1.23.0
+  rev: v1.25.1
   hooks:
   - id: pyupgrade
     args: ["--py36-plus"]
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.3.0
+  rev: v2.4.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,21 +5,21 @@
 #    pip-compile setup.py
 #
 appdirs==1.4.3            # via fs
-booleanoperations==0.8.2
-brotli==1.0.7
+booleanoperations==0.9.0
+brotli==1.0.7             # via fonttools
 compreffor==0.4.6.post1   # via ufo2ft
 cu2qu==1.6.6              # via ufo2ft
 defcon==0.6.0
-fonttools[lxml,ufo,unicode]==3.44.0
+fonttools[lxml,type1,ufo,unicode,woff]==4.1.0
 fs==2.4.11                # via fonttools
 hsluv==0.0.2
 lxml==4.4.1               # via fonttools
 pyclipper==1.1.0.post1    # via booleanoperations
-pyqt5-sip==4.19.18        # via pyqt5
-pyqt5==5.13.0
+pyqt5-sip==12.7.0         # via pyqt5
+pyqt5==5.13.2
 pytz==2019.3              # via fs
-six==1.12.0               # via fs
-ufo-extractor==0.2.0
-ufo2ft==2.9.1
-ufolib==2.3.2             # via ufo-extractor
-unicodedata2==12.0.0      # via fonttools
+six==1.13.0               # via fs
+ufo-extractor==0.3.0
+ufo2ft==2.10.0
+unicodedata2==12.1.0      # via fonttools
+zopfli==0.1.6             # via fonttools

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,12 +31,11 @@ setup_requires =
     wheel
 install_requires =
     booleanOperations >= 0.7.0
-    brotli >= 0.5.2
     defcon >= 0.6.0
-    fonttools[unicode,ufo,lxml] >= 3.40.0, <4  # Until we get rid of ufoLib dependency
+    fonttools[unicode,ufo,lxml,woff] >= 4.0.0
     hsluv >= 0.0.2
     pyqt5 >= 5.5.0
-    ufo-extractor >= 0.2.0
+    ufo-extractor >= 0.3.0
     ufo2ft >= 0.5.3
 
 [options.packages.find]


### PR DESCRIPTION
This finally gets rid of the old ufoLib dependency.

Closes #684.

Hopefully.