### PR TITLE
Set application title on macOS

### DIFF
--- a/Lib/trufont/__main__.py
+++ b/Lib/trufont/__main__.py
@@ -17,11 +17,13 @@ from trufont.windows.outputWindow import OutputWindow
 
 def main():
     global app
+
     # register representation factories
     baseRepresentationFactories.registerAllFactories()
     representationFactories.registerAllFactories()
     if hasattr(Qt, "AA_EnableHighDpiScaling"):
         QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
+    platformSpecific.setAppName()
     # initialize the app
     app = Application(sys.argv)
     app.setOrganizationName("TruFont")

--- a/Lib/trufont/tools/platformSpecific.py
+++ b/Lib/trufont/tools/platformSpecific.py
@@ -134,11 +134,12 @@ def setAppName():
         # Python 3: pip3 install pyobjc-framework-Cocoa
         try:
             from Foundation import NSBundle
+
             bundle = NSBundle.mainBundle()
             if bundle:
                 app_info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
                 if app_info:
-                    app_info['CFBundleName'] = "TruFont"
+                    app_info["CFBundleName"] = "TruFont"
         except ImportError as e:
             print(f"Could not set title: {e}")
             pass

--- a/Lib/trufont/tools/platformSpecific.py
+++ b/Lib/trufont/tools/platformSpecific.py
@@ -130,6 +130,7 @@ def setAppName():
     if sys.platform == "darwin":
         try:
             from Foundation import NSBundle
+
             bundle = NSBundle.mainBundle()
             if bundle:
                 app_info = bundle.localizedInfoDictionary() or bundle.infoDictionary()

--- a/Lib/trufont/tools/platformSpecific.py
+++ b/Lib/trufont/tools/platformSpecific.py
@@ -126,6 +126,24 @@ def windowCommandsInMenu():
     return sys.platform == "darwin"
 
 
+def setAppName():
+    if sys.platform == "darwin":
+        # Adapted from https://stackoverflow.com/a/54755290
+        # Requires PyObjC
+        # Python 2 has PyObjC preinstalled.
+        # Python 3: pip3 install pyobjc-framework-Cocoa
+        try:
+            from Foundation import NSBundle
+            bundle = NSBundle.mainBundle()
+            if bundle:
+                app_info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
+                if app_info:
+                    app_info['CFBundleName'] = "TruFont"
+        except ImportError as e:
+            print(f"Could not set title: {e}")
+            pass
+
+
 # -----------
 # Main window
 # -----------

--- a/Lib/trufont/tools/platformSpecific.py
+++ b/Lib/trufont/tools/platformSpecific.py
@@ -128,13 +128,8 @@ def windowCommandsInMenu():
 
 def setAppName():
     if sys.platform == "darwin":
-        # Adapted from https://stackoverflow.com/a/54755290
-        # Requires PyObjC
-        # Python 2 has PyObjC preinstalled.
-        # Python 3: pip3 install pyobjc-framework-Cocoa
         try:
             from Foundation import NSBundle
-
             bundle = NSBundle.mainBundle()
             if bundle:
                 app_info = bundle.localizedInfoDictionary() or bundle.infoDictionary()

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     pyqt5 >= 5.5.0
     ufo-extractor >= 0.3.0
     ufo2ft >= 0.5.3
+    pyobjc-framework-cocoa >= 6.2 ; sys_platform == 'darwin'
 
 [options.packages.find]
 where = Lib


### PR DESCRIPTION
Changes the application title from the default "Python" to "TruFont" for macOS.
It requires pyobjc-framework-Cocoa.

Fixes the macOS side of #555