### PR TITLE
Disable find menu entry when not in Glyph View

### DIFF
--- a/Lib/trufont/windows/fontWindow.py
+++ b/Lib/trufont/windows/fontWindow.py
@@ -247,7 +247,7 @@ class FontWindow(BaseWindow):
         self._clipboardActions = (cut, copy, copyComponent, paste)
         editMenu.fetchAction(Entries.Edit_Select_All, self.selectAll)
         # editMenu.fetchAction(Entries.Edit_Deselect, self.deselect)
-        editMenu.fetchAction(Entries.Edit_Find, self.findGlyph)
+        self._findAction = editMenu.fetchAction(Entries.Edit_Find, self.findGlyph)
         editMenu.addSeparator()
         editMenu.fetchAction(Entries.Edit_Settings)
 
@@ -1063,8 +1063,10 @@ class FontWindow(BaseWindow):
         widget = self.stackWidget.currentWidget()
         if self.isGlyphTab():
             currentGlyph = widget.activeGlyph()
+            self._findAction.setEnabled(True)
         else:
             currentGlyph = widget.lastSelectedGlyph()
+            self._findAction.setEnabled(False)
         # disconnect eventual signal of previous glyph
         objects = ((self._undoAction, self.undo), (self._redoAction, self.redo))
         for action, slot in objects:


### PR DESCRIPTION
It took me forever to discover that the Find menu action was hooked up all the time, but silently ignored when not in the Glyph View. Disabling the Find menu item when not in Glyph View provides visual feedback that the menu isn't active in the main window, thus reducing frustration for new users. This may help a tiny bit with issue #138.