### PR TITLE
Hook up control/W on main window to close open font

### DIFF
--- a/Lib/trufont/windows/fontWindow.py
+++ b/Lib/trufont/windows/fontWindow.py
@@ -361,6 +361,8 @@ class FontWindow(BaseWindow):
         index = self.stackWidget.currentIndex()
         if index:
             self.tabWidget.removeTab(index)
+        else:
+            self.close()
 
     def maybeSaveBeforeExit(self):
         if self._font.dirty:


### PR DESCRIPTION
I often edit multiple fonts by starting trufont from the command line with a wildcard file specification. There is no key shortcut for closing a font window; but individual tabs can be closed with ctrl/W, and ctrl/Q closes all windows. This pull request generalizes ctrl/W to close either a glyph tab or the main window. For repetitive actions, this greatly reduces required mouse actions for my use case (and with laptop mice being finicky creatures, this prevents the occasional mishap when I'm editing fonts on the road).

I cannot foresee any user confusion as a result of this change, but I'm no UX expert.