### PR TITLE
Bump GlyphCellHeaderHeight to 15 (from 13) for Linux.

### DIFF
--- a/Lib/defconQt/representationFactories/glyphCellFactory.py
+++ b/Lib/defconQt/representationFactories/glyphCellFactory.py
@@ -4,7 +4,7 @@ from PyQt5.QtGui import QColor, QFontMetrics, QPainter, QPainterPath, QPixmap
 from defconQt.tools import platformSpecific
 from defconQt.tools.drawing import colorToQColor
 
-GlyphCellHeaderHeight = 13
+GlyphCellHeaderHeight = platformSpecific.glyphCellHeaderHeight()
 GlyphCellMinHeightForHeader = 40
 GlyphCellMinHeightForMetrics = 100
 

--- a/Lib/defconQt/tools/platformSpecific.py
+++ b/Lib/defconQt/tools/platformSpecific.py
@@ -82,6 +82,12 @@ def otherUIFont():
     return font
 
 
+def glyphCellHeaderHeight():
+    if sys.platform.startswith("linux"):
+        return 15
+    return 13
+
+
 # ----
 # Keys
 # ----


### PR DESCRIPTION
Bump GlyphCellHeaderHeight to 15 (from 13) for Linux. This fixes the clipping mentioned in issue #438, at least on my system (Ubuntu 20.04).

Reworked to use platform specific helper function, replacing PR 764. For optimum results, should be reworked to actually measure UI font height.