### PR TITLE
Use fontmetrics for header height

### DIFF
--- a/Lib/defconQt/representationFactories/glyphCellFactory.py
+++ b/Lib/defconQt/representationFactories/glyphCellFactory.py
@@ -4,7 +4,7 @@ from PyQt5.QtGui import QColor, QFontMetrics, QPainter, QPainterPath, QPixmap
 from defconQt.tools import platformSpecific
 from defconQt.tools.drawing import colorToQColor
 
-GlyphCellHeaderHeight = platformSpecific.glyphCellHeaderHeight()
+GlyphCellHeaderHeight = 0
 GlyphCellMinHeightForHeader = 40
 GlyphCellMinHeightForMetrics = 100
 
@@ -92,8 +92,10 @@ class GlyphCellFactoryDrawingController:
         self.shouldDrawMarkColor = drawMarkColor
         self.shouldDrawMetrics = drawMetrics
 
-        fontMetrics = QFontMetrics(headerFont)
-        GlyphCellHeaderHeight = fontMetrics.height() + 3
+        global GlyphCellHeaderHeight
+        if GlyphCellHeaderHeight == 0:
+            fontMetrics = QFontMetrics(headerFont)
+            GlyphCellHeaderHeight = fontMetrics.height() + 3
 
         self.headerAtBottom = True
         self.headerHeight = 0

--- a/Lib/defconQt/representationFactories/glyphCellFactory.py
+++ b/Lib/defconQt/representationFactories/glyphCellFactory.py
@@ -92,6 +92,9 @@ class GlyphCellFactoryDrawingController:
         self.shouldDrawMarkColor = drawMarkColor
         self.shouldDrawMetrics = drawMetrics
 
+        fontMetrics = QFontMetrics(headerFont)
+        GlyphCellHeaderHeight = fontMetrics.height()
+
         self.headerAtBottom = True
         self.headerHeight = 0
         if drawHeader:

--- a/Lib/defconQt/representationFactories/glyphCellFactory.py
+++ b/Lib/defconQt/representationFactories/glyphCellFactory.py
@@ -93,7 +93,7 @@ class GlyphCellFactoryDrawingController:
         self.shouldDrawMetrics = drawMetrics
 
         fontMetrics = QFontMetrics(headerFont)
-        GlyphCellHeaderHeight = fontMetrics.height()
+        GlyphCellHeaderHeight = fontMetrics.height() + 3
 
         self.headerAtBottom = True
         self.headerHeight = 0
@@ -284,6 +284,6 @@ class GlyphCellFactoryDrawingController:
             0,
             width - 2,
             height - minOffset,
-            Qt.TextSingleLine | Qt.AlignCenter | Qt.AlignBottom,
+            Qt.TextSingleLine | Qt.AlignHCenter | Qt.AlignBottom,
             name,
         )

--- a/Lib/defconQt/tools/platformSpecific.py
+++ b/Lib/defconQt/tools/platformSpecific.py
@@ -82,12 +82,6 @@ def otherUIFont():
     return font
 
 
-def glyphCellHeaderHeight():
-    if sys.platform.startswith("linux"):
-        return 15
-    return 13
-
-
 # ----
 # Keys
 # ----


### PR DESCRIPTION
This pull request eliminates hard coded pixel sizes for the header text.

I've still got no clue why clipping occurs if headerHeight is not at least three pixels larger than the pixel height of the font metrics according to Qt5, as I can only account for one pixel, but the glyphCell widgets look good with this change applied on Windows and on Linux, and it gets rid of the hard coded size in pixels. I experimented by drawing a yellow rectangle underneath the text string in drawCellHeaderText and it does seem the clipping comes from painter.drawText (but I'm no Qt5 guru and Python is not my mother tongue).

The inconsistency between my laptop and my desktop disappeared after I installed B&H Luxi Sans. I do not have a better suggestion for a UI font off the top off my head (well, I do, but I'm biased and DINish doesn't come with any Linux distros either :-)

The Qt5 docs suggest but do not spell out that Qt.AlignCenter | Qt.AlignBottom should be Qt.AlignHCenter | Qt.AlignBottom; I'd suggest to make that change for readability.

I verified that this code seems to do the right thing on Ubuntu 20.04LTS and on Windows 10 21H1, but I could not test on MacOS.

Tweaking GlyphCellHeaderHeight from GlyphCellFactoryDrawingController is of course a gross hack, but I could not find a better place to do it (and the usage of GlyphCellHeaderHeight in glyphCellFactory.py and glyphView.py is hackish in its own right, as it's neither a class nor an instance variable).