### PR TITLE
Visualize curvatures

### DIFF
--- a/Lib/defconQt/controls/glyphContextView.py
+++ b/Lib/defconQt/controls/glyphContextView.py
@@ -41,7 +41,7 @@ class GlyphContextView(QWidget):
         self.setFocusPolicy(Qt.ClickFocus)
         self.grabGesture(Qt.PanGesture)
         self.grabGesture(Qt.PinchGesture)
-        self._drawingOffset = QPoint()
+        self._drawingOffset = QPointF()
         self._fitViewport = True
         self._glyphRecords = []
         self._glyphRecordsRects = {}
@@ -284,7 +284,7 @@ class GlyphContextView(QWidget):
         dx = 0.5 * (fitWidth - glyph.width * self._scale) - otherWidth * self._scale
         dy = 0.5 * (fitHeight - height * self._scale) + top * self._scale
         # TODO: round?
-        self._drawingOffset = QPoint(int(dx), int(dy))
+        self._drawingOffset = QPointF(dx, dy)
         self.pointSizeModified.emit(self._impliedPointSize)
 
     def fitScaleBBox(self):
@@ -316,7 +316,7 @@ class GlyphContextView(QWidget):
         )
         dy = 0.5 * (fitHeight - glyphHeight * self._scale) + top * self._scale
         # TODO: round?
-        self._drawingOffset = QPoint(dx, dy)
+        self._drawingOffset = QPointF(dx, dy)
         self.pointSizeModified.emit(self._impliedPointSize)
 
     def scrollBy(self, point):
@@ -354,7 +354,7 @@ class GlyphContextView(QWidget):
         elif anchor == "cursor":
             pos = self.mapFromGlobal(QCursor.pos())
         elif anchor == "center":
-            pos = QPoint(0.5 * self.width(), 0.5 * self.height())
+            pos = QPointF(0.5 * self.width(), 0.5 * self.height())
         else:
             raise ValueError(f"invalid anchor value: {anchor}")
         deltaToPos = pos / oldScale - self._drawingOffset / oldScale
@@ -405,7 +405,7 @@ class GlyphContextView(QWidget):
                 break
             x -= glyphRecord.xAdvance
             y -= glyphRecord.yAdvance
-        return pos.__class__(x, y)
+        return pos.__class__(int(x), int(y))
 
     def mapRectFromCanvas(self, rect):
         x, y, w, h = rect.getRect()
@@ -795,7 +795,7 @@ class GlyphContextView(QWidget):
                 delta = event.angleDelta()
                 dx = delta.x() / 120 * QApplication.wheelScrollLines() * 8
                 dy = delta.y() / 120 * QApplication.wheelScrollLines() * 8
-                delta = QPoint(dx, dy)
+                delta = QPointF(dx, dy)
             self._drawingOffset += delta
             self.update()
         event.accept()

--- a/Lib/defconQt/controls/glyphContextView.py
+++ b/Lib/defconQt/controls/glyphContextView.py
@@ -60,6 +60,7 @@ class GlyphContextView(QWidget):
             showGlyphBezierHandlesCoordinates=False,
             showGlyphCoordinatesWhenSelected=False,
             showGlyphAnchors=True,
+            showGlyphCurvatures=True,
             showGlyphMetrics=True,
             showGlyphGuidelines=True,
             showGlyphImage=True,
@@ -505,6 +506,12 @@ class GlyphContextView(QWidget):
     def setShowPointCoordinates(self, value):
         self.setDefaultDrawingAttribute("showGlyphPointCoordinates", value)
 
+    def showCurvatures(self):
+        return self.defaultDrawingAttribute("showGlyphCurvatures")
+
+    def setShowCurvatures(self, value):
+        self.setDefaultDrawingAttribute("showGlyphCurvatures", value)
+
     def showAnchors(self):
         return self.defaultDrawingAttribute("showGlyphAnchors")
 
@@ -570,6 +577,8 @@ class GlyphContextView(QWidget):
             "showGlyphComponentStroke", flags
         ):
             self.drawStroke(painter, glyph, flags)
+        if self.drawingAttribute("showGlyphCurvatures", flags):
+            self.drawCurvatures(painter, glyph, flags)
         if self.drawingAttribute("showGlyphAnchors", flags):
             self.drawAnchors(painter, glyph, flags)
 
@@ -654,6 +663,14 @@ class GlyphContextView(QWidget):
             drawComponentsFill=False,
             drawStroke=drawStroke,
             drawComponentStroke=drawComponentStroke,
+        )
+
+    def drawCurvatures(self, painter, glyph, flags):
+        # TODO: let user adjust curve scale
+        scale = self._ascender * 2.5
+        drawCurvatures = self.drawingAttribute("showGlyphCurvatures", flags)
+        drawing.drawGlyphCurvatures(
+            painter, glyph, scale, drawCurvatures=drawCurvatures
         )
 
     def drawAnchors(self, painter, glyph, flags):

--- a/Lib/defconQt/controls/glyphLineView.py
+++ b/Lib/defconQt/controls/glyphLineView.py
@@ -446,7 +446,7 @@ class GlyphLineWidget(QWidget):
                     curWidth += gWidth
                 width = max(curWidth, width)
             height += lines * self._pointSize * self._lineHeight
-        return QSize(width, height)
+        return QSize(int(width), int(height))
 
     # ------------
     # Input events
@@ -567,7 +567,7 @@ class GlyphLineWidget(QWidget):
                 drawing.drawLine(
                     painter, xMin + width, yMin, xMin + width, yMin + height
                 )
-            painter.fillRect(xMin, yMin, width, -26, selectionColor)
+            painter.fillRect(int(xMin), int(yMin), int(width), -26, selectionColor)
             painter.restore()
 
     def drawImage(self, painter, glyph, layerName, rect):

--- a/Lib/defconQt/representationFactories/__init__.py
+++ b/Lib/defconQt/representationFactories/__init__.py
@@ -5,6 +5,7 @@ from defconQt.representationFactories.glyphViewFactory import (
     NoComponentsQPainterPathFactory,
     OnlyComponentsQPainterPathFactory,
     OutlineInformationFactory,
+    CurvatureInformationFactory,
     QPixmapFactory,
 )
 from defconQt.representationFactories.qPainterPathFactory import QPainterPathFactory
@@ -17,6 +18,10 @@ _glyphFactories = {
     "defconQt.GlyphCell": (GlyphCellFactory, None),
     "defconQt.OutlineInformation": (
         OutlineInformationFactory,
+        ("Glyph.Changed", "Glyph.SelectionChanged"),
+    ),
+    "defconQt.CurvatureInformation": (
+        CurvatureInformationFactory,
         ("Glyph.Changed", "Glyph.SelectionChanged"),
     ),
 }

--- a/Lib/defconQt/tools/curvature.py
+++ b/Lib/defconQt/tools/curvature.py
@@ -1,0 +1,84 @@
+from math import comb
+from fontTools.misc import bezierTools
+
+
+def getArcLength(p_list):
+    return bezierTools.calcCubicArcLength(p_list[0], p_list[1], p_list[2], p_list[3])
+
+
+def getBezierCoeffs(px, b_order):
+    """
+    Computes the bezier coefficients
+    """
+    # TODO: simplify for quadratic and cubic to improve performance
+
+    coeffs = []
+
+    for i in range(b_order + 1):
+        cc = 0
+        sig = 1 if (i % 2 == 0) else -1
+        for j in range(i + 1):
+            cc = cc + px[j] * sig * comb(i, j)
+            sig = -sig
+        coeffs.append(cc)
+    return coeffs
+
+
+def getCurvature(px, py, t):
+    """
+    Computes the curvature at parameter t, where t is in [0, 1].
+
+    Returns the x, y values for parameter r, the tangent vectors dx, dy and the
+    curvature value c
+    """
+
+    b_order = len(px) - 1
+
+    # Calculate coefficients
+    ax = getBezierCoeffs(px, b_order)
+    ay = getBezierCoeffs(py, b_order)
+
+    # Calculate curve points
+    tn = []
+    for i in range(b_order + 1):
+        tn.append(t ** i)
+
+    coeffs = [comb(b_order, i) for i in range(b_order + 1)]
+
+    x_t = 0
+    y_t = 0
+    for i in range(b_order + 1):
+        x_t = x_t + coeffs[i] * ax[i] * tn[i]
+        y_t = y_t + coeffs[i] * ay[i] * tn[i]
+
+    # Calculate curvature
+    # Derivatives
+    coeffs1 = [comb(b_order - 1, i) * b_order for i in range(b_order)]
+
+    x_dot = 0
+    y_dot = 0
+    for i in range(b_order):
+        x_dot = x_dot + coeffs1[i] * ax[i + 1] * tn[i]
+        y_dot = y_dot + coeffs1[i] * ay[i + 1] * tn[i]
+
+    # Tangent vectors
+    d_dot = (x_dot ** 2 + y_dot ** 2) ** 0.5
+    if d_dot == 0:
+        return {"x": x_t, "y": y_t, "dx": 0, "dy": 0, "c": 0}
+    ex = x_dot / d_dot
+    ey = y_dot / d_dot
+
+    # 2nd derivatives
+    coeffs2 = [
+        comb(b_order - 2, i) * (b_order) * (b_order - 1) for i in range(b_order - 1)
+    ]
+
+    x_2dot = 0
+    y_2dot = 0
+    for i in range(b_order - 1):
+        x_2dot = x_2dot + coeffs2[i] * ax[i + 2] * tn[i]
+        y_2dot = y_2dot + coeffs2[i] * ay[i + 2] * tn[i]
+
+    cvt = (x_2dot * y_dot - y_2dot * x_dot) / abs(x_dot ** 2 + y_dot ** 2) ** (3 / 2)
+
+    return {"x": x_t, "y": y_t, "dx": ex, "dy": ey, "c": cvt}

--- a/Lib/defconQt/tools/drawing.py
+++ b/Lib/defconQt/tools/drawing.py
@@ -18,7 +18,7 @@ from defcon import Color
 from fontTools.misc.transform import Identity
 from fontTools.pens.qtPen import QtPen
 from fontTools.pens.transformPen import TransformPen
-from PyQt5.QtCore import QLineF, QPointF, Qt
+from PyQt5.QtCore import QLineF, QPointF, QRectF, Qt
 from PyQt5.QtGui import (
     QBrush,
     QColor,
@@ -411,7 +411,7 @@ def drawFontPostscriptFamilyBlues(painter, glyph, scale, color=None):
 
 def _drawBlues(painter, glyph, blues, color):
     for yMin, yMax in zip(blues[::2], blues[1::2]):
-        painter.fillRect(0, yMin, glyph.width, yMax - yMin, color)
+        painter.fillRect(QRectF(0, yMin, glyph.width, yMax - yMin), color)
 
 
 # Image
@@ -482,12 +482,12 @@ def drawGlyphMetrics(
         lo = metrics[0]
         hi = max(y for y in metrics[-2:] if y is not None)
         painter.drawLine(0, lo, 0, hi)
-        painter.drawLine(glyph.width, lo, glyph.width, hi)
+        painter.drawLine(QPointF(glyph.width, lo), QPointF(glyph.width, hi))
     if drawVMetrics:
         for y in metrics:
             if y is None:
                 continue
-            painter.drawLine(0, y, glyph.width, y)
+            painter.drawLine(QPointF(0, y), QPointF(glyph.width, y))
     painter.restore()
     # metrics text
     if drawText:

--- a/Lib/defconQt/tools/drawing.py
+++ b/Lib/defconQt/tools/drawing.py
@@ -770,14 +770,14 @@ def drawGlyphPoints(
 # Curvature
 
 
-def toCurvaturePoint(crvData, curveScale):
+def toCurvaturePoint(crvData, crvScale):
     return (
-        crvData["x"] - crvData["dy"] * crvData["c"] * curveScale,
-        crvData["y"] + crvData["dx"] * crvData["c"] * curveScale,
+        crvData["x"] - crvData["dy"] * crvData["c"] * crvScale,
+        crvData["y"] + crvData["dx"] * crvData["c"] * crvScale,
     )
 
 
-def drawGlyphCurvatures(painter, glyph, scale, drawCurvatures=True):
+def drawGlyphCurvatures(painter, glyph, scale, curvatureScale, drawCurvatures=True):
     # Drawing piece-wise linear for now
     if drawCurvatures:
         curvatureData = glyph.getRepresentation("defconQt.CurvatureInformation")
@@ -789,7 +789,9 @@ def drawGlyphCurvatures(painter, glyph, scale, drawCurvatures=True):
         for curvatureInfo in curvatureData:
             # Curvature
             # Translate to points
-            curvaturePoints = [toCurvaturePoint(info, scale) for info in curvatureInfo]
+            curvaturePoints = [
+                toCurvaturePoint(info, curvatureScale) for info in curvatureInfo
+            ]
             # Path
             curvaturePath.moveTo(curvaturePoints[0][0], curvaturePoints[0][1])
             for pt in curvaturePoints[1:]:
@@ -805,13 +807,13 @@ def drawGlyphCurvatures(painter, glyph, scale, drawCurvatures=True):
 
         # Draw curvature
         curvePen = QPen(QColor.fromRgbF(1, 0, 0, 1))
-        curvePen.setWidth(1)
+        curvePen.setWidthF(1 * scale)
         painter.setPen(curvePen)
         painter.drawPath(curvaturePath)
 
         # Draw stems
         stemPen = QPen(QColor.fromRgbF(1, 0, 0, 0.7))
-        stemPen.setWidth(1)
+        stemPen.setWidthF(0.5 * scale)
         painter.setPen(stemPen)
         painter.drawPath(stemPath)
 

--- a/Lib/defconQt/tools/drawing.py
+++ b/Lib/defconQt/tools/drawing.py
@@ -767,6 +767,57 @@ def drawGlyphPoints(
         painter.restore()
 
 
+# Curvature
+
+
+def toCurvaturePoint(crvData, curveScale):
+    return (
+        crvData["x"] - crvData["dy"] * crvData["c"] * curveScale,
+        crvData["y"] + crvData["dx"] * crvData["c"] * curveScale,
+    )
+
+
+def drawGlyphCurvatures(painter, glyph, scale, drawCurvatures=True):
+    # Drawing piece-wise linear for now
+    if drawCurvatures:
+        curvatureData = glyph.getRepresentation("defconQt.CurvatureInformation")
+
+        # Create Paths
+        curvaturePath = QPainterPath()
+        stemPath = QPainterPath()
+
+        for curvatureInfo in curvatureData:
+            # Curvature
+            # Translate to points
+            curvaturePoints = [toCurvaturePoint(info, scale) for info in curvatureInfo]
+            # Path
+            curvaturePath.moveTo(curvaturePoints[0][0], curvaturePoints[0][1])
+            for pt in curvaturePoints[1:]:
+                curvaturePath.lineTo(pt[0], pt[1])
+
+            # Stems
+            for segPoint, crvPoint in zip(curvatureInfo, curvaturePoints):
+                stemPath.moveTo(segPoint["x"], segPoint["y"])
+                stemPath.lineTo(crvPoint[0], crvPoint[1])
+
+        # Draw
+        painter.save()
+
+        # Draw curvature
+        curvePen = QPen(QColor.fromRgbF(1, 0, 0, 1))
+        curvePen.setWidth(1)
+        painter.setPen(curvePen)
+        painter.drawPath(curvaturePath)
+
+        # Draw stems
+        stemPen = QPen(QColor.fromRgbF(1, 0, 0, 0.7))
+        stemPen.setWidth(1)
+        painter.setPen(stemPen)
+        painter.drawPath(stemPath)
+
+        painter.restore()
+
+
 # Anchors
 
 

--- a/Lib/trufont/controls/statusBar.py
+++ b/Lib/trufont/controls/statusBar.py
@@ -1,6 +1,6 @@
 from PyQt5.QtCore import QSize, Qt
 from PyQt5.QtGui import QColor, QPainter, QPainterPath
-from PyQt5.QtWidgets import QHBoxLayout, QLabel, QSizePolicy, QSpinBox, QWidget
+from PyQt5.QtWidgets import QHBoxLayout, QLabel, QSizePolicy, QSpinBox, QWidget, QSlider
 
 from trufont.controls.pathButton import PathButton
 
@@ -26,6 +26,15 @@ def Button():
     return btn
 
 
+def Slider(parent):
+    slider = QSlider(Qt.Horizontal, parent)
+    slider.setFixedWidth(56)
+    slider.setMinimum(-100)
+    slider.setMaximum(100)
+    slider.setValue(0)
+    return slider
+
+
 class StatusBar(QWidget):
     """
     Use the *sizeChanged* signal for size changes.
@@ -39,6 +48,11 @@ class StatusBar(QWidget):
         self._shouldPropagateSize = True
 
         self.statusLabel = QLabel(self)
+
+        self.curveSlider = Slider(self)
+        self.curveSlider.setVisible(False)
+        self.curveSlider.valueChanged.connect(self._sliderValueChanged)
+        self._curvatureScale = self.curveSlider.value()
 
         btnColor = QColor(126, 126, 126)
         minusButton = Button()
@@ -57,6 +71,7 @@ class StatusBar(QWidget):
 
         layout = QHBoxLayout(self)
         layout.addWidget(self.statusLabel)
+        layout.addWidget(self.curveSlider)
         spacer = QWidget()
         spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
         layout.addWidget(spacer)
@@ -67,6 +82,7 @@ class StatusBar(QWidget):
         layout.setSpacing(0)
 
         self.sizeChanged = self.sizeEdit.valueChanged
+        self.curvatureScaleChanged = self.curveSlider.valueChanged
 
     def text(self):
         return self.statusLabel.text()
@@ -79,6 +95,12 @@ class StatusBar(QWidget):
 
     def setTextVisible(self, value):
         self.statusLabel.setVisible(value)
+
+    def sliderVisible(self):
+        return self.curveSlider.isVisible()
+
+    def setSliderVisible(self, value):
+        self.curveSlider.setVisible(value)
 
     def minimumSize(self):
         return self.sizeEdit.minimum()
@@ -121,6 +143,12 @@ class StatusBar(QWidget):
         # nudge label w unclamped value
         self._sliderSizeChanged(value)
 
+    def curvatureScale(self):
+        return self.curveSlider.value()
+
+    def setCurvatureScale(self, value):
+        self.curveSlider.setValue(value)
+
     def paintEvent(self, event):
         painter = QPainter(self)
         painter.fillRect(event.rect(), Qt.white)
@@ -133,3 +161,8 @@ class StatusBar(QWidget):
 
     def _sliderSizeChanged(self, value):
         self.sizeEdit.setValue(value)
+
+    def _sliderValueChanged(self, value):
+        if value != self._curvatureScale:
+            self._curvatureScale = value
+            self.curveSlider.valueChanged.emit(value)

--- a/Lib/trufont/objects/application.py
+++ b/Lib/trufont/objects/application.py
@@ -416,7 +416,7 @@ class Application(QApplication):
                 )
                 supportedFiles += "*.otf *.pfa *.pfb *.ttf *.ttx *.woff"
             all_supported_types_filter = self.tr("All supported files {}").format(
-                "({})".format(supportedFiles.rstrip())
+                f"({supportedFiles.rstrip()})"
             )
             fileFormats.extend(
                 [all_supported_types_filter, self.tr("All files {}").format("(*.*)")]
@@ -699,6 +699,7 @@ class Application(QApplication):
                 ),
                 True,
             ),
+            (Entries.View_Show_Curvatures, ("showGlyphCurvatures",), True,),
             (Entries.View_Show_Images, ("showGlyphImage",), True,),
             (
                 Entries.View_Show_Guidelines,

--- a/Lib/trufont/objects/icons.py
+++ b/Lib/trufont/objects/icons.py
@@ -1,6 +1,7 @@
 """
 Icon database, issues drawing commands. PathButton is a consumer.
 """
+
 from PyQt5.QtCore import QSize
 from PyQt5.QtGui import QColor, QPainterPath, QTransform
 

--- a/Lib/trufont/objects/menu.py
+++ b/Lib/trufont/objects/menu.py
@@ -6,6 +6,7 @@ Windows that want to plug-in their own menu entries must implement
 - setMenuBar(menuBar)
 
 """
+
 from PyQt5.QtGui import QKeySequence
 from PyQt5.QtWidgets import QAction, QApplication, QMenu, QMenuBar
 
@@ -135,6 +136,7 @@ class Entries:
     View_Show_Coordinates_When_Selected = "Show Coordinates When &Selected"
     View_Show_Point_Coordinates = "Always Show &Point Coordinates"
     View_Show_Bezier_Handles_Coordinates = "Always Show &Bezier Handles Coordinates"
+    View_Show_Curvatures = "Show C&urvatures"
     View_Show_Metrics = "Show &Metrics"
     View_Show_Images = "Show &Images"
     View_Show_Guidelines = "Show &Guidelines"
@@ -193,6 +195,7 @@ _shortcuts = {
     Entries.View_Layer_Up: "PgUp",
     Entries.View_Layer_Down: "PgDown",
     Entries.View_Show_Points: "Ctrl+Shift+N",
+    Entries.View_Show_Curvatures: "Ctrl+Shift+C",
     Entries.View_Show_Metrics: "Ctrl+Shift+M",
     Entries.View_Show_Guidelines: "Ctrl+Shift+G",
     Entries.Font_Font_Info: "Ctrl+Alt+I",
@@ -260,6 +263,7 @@ def globalMenuBar():
     coordinatesSubmenu.fetchAction(Entries.View_Show_Coordinates_When_Selected)
     coordinatesSubmenu.fetchAction(Entries.View_Show_Point_Coordinates)
     coordinatesSubmenu.fetchAction(Entries.View_Show_Bezier_Handles_Coordinates)
+    viewMenu.fetchAction(Entries.View_Show_Curvatures)
     viewMenu.fetchAction(Entries.View_Show_Metrics)
     viewMenu.fetchAction(Entries.View_Show_Images)
     viewMenu.fetchAction(Entries.View_Show_Guidelines)

--- a/Lib/trufont/tools/drawing.py
+++ b/Lib/trufont/tools/drawing.py
@@ -325,8 +325,8 @@ def drawGlyphFillAndStroke(
             pen.setWidth(0)
             painter.setPen(pen)
             for x, y in originPts:
-                painter.drawLine(x, y + 5 * scale, x, y)
-                painter.drawLine(x, y, x + 4.5 * scale, y)
+                painter.drawLine(QPointF(x, y + 5 * scale), QPointF(x, y))
+                painter.drawLine(QPointF(x, y), QPointF(x + 4.5 * scale, y))
             painter.restore()
     # selection
     if drawSelection:
@@ -659,9 +659,9 @@ def drawGrid(painter, scale, rect, color=None):
     pen.setWidth(0)
     painter.setPen(pen)
     while x > xMin:
-        painter.drawLine(x, yMin, x, yMax)
+        painter.drawLine(QPointF(x, yMin), QPointF(x, yMax))
         x -= 1
     while y > yMin:
-        painter.drawLine(xMin, y, xMax, y)
+        painter.drawLine(QPointF(xMin, y), QPointF(xMax, y))
         y -= 1
     painter.restore()

--- a/Lib/trufont/tools/uiMethods.py
+++ b/Lib/trufont/tools/uiMethods.py
@@ -1,6 +1,7 @@
 """
 UI-constrained point management methods.
 """
+
 import itertools
 
 from PyQt5.QtCore import QLineF, QPointF

--- a/Lib/trufont/windows/fontInfoWindow.py
+++ b/Lib/trufont/windows/fontInfoWindow.py
@@ -812,7 +812,7 @@ class OpenTypeTab(TabWidget):
         if wc and wc % 100 == 0:
             usWeightClassLabel.setChecked(True)
             self.usWeightClassDrop.setCurrentIndex(
-                font.info.openTypeOS2WeightClass / 100 - 1
+                int(font.info.openTypeOS2WeightClass / 100) - 1
             )
         else:
             self.usWeightClassDrop.setEnabled(False)

--- a/Lib/trufont/windows/fontWindow.py
+++ b/Lib/trufont/windows/fontWindow.py
@@ -143,6 +143,7 @@ class FontWindow(BaseWindow):
         self.statusBar.setMinimumSize(32)
         self.statusBar.setMaximumSize(128)
         self.statusBar.sizeChanged.connect(self._sizeChanged)
+        self.statusBar.curvatureScaleChanged.connect(self._curvatureScaleChanged)
 
         self.setFont_(font)
 
@@ -352,6 +353,7 @@ class FontWindow(BaseWindow):
         widget.glyphNamesChanged.connect(self._namesChanged)
         widget.pointSizeModified.connect(self.statusBar.setSize)
         widget.toolModified.connect(self.toolBar.setCurrentTool)
+        widget.showCurvatureChanged.connect(self.statusBar.setSliderVisible)
         # add
         self.tabWidget.addTab(_textForGlyphs([glyph]))
         self.stackWidget.addWidget(widget)
@@ -428,6 +430,11 @@ class FontWindow(BaseWindow):
         else:
             self.glyphCellView.setCellSize(size)
 
+    def _curvatureScaleChanged(self):
+        value = self.statusBar.curvatureScale()
+        widget = self.stackWidget.currentWidget()
+        widget.setCurvatureScale(value)
+
     def _tabChanged(self, index):
         self.statusBar.setShouldPropagateSize(not index)
         # we need to hide, then setParent, then show
@@ -457,9 +464,15 @@ class FontWindow(BaseWindow):
             lo, hi, unit = 0, 900_000, " pt"
             widget = self.stackWidget.currentWidget()
             size = widget.pointSize()
+
+            self.statusBar.setSliderVisible(widget.showCurvatures())
+            self.statusBar.setCurvatureScale(widget.curvatureScale())
         else:
             lo, hi, unit = 32, 128, None
             size = self.glyphCellView.cellSize()[0]
+
+            self.statusBar.setSliderVisible(False)
+
         self.statusBar.setMinimumSize(lo)
         self.statusBar.setMaximumSize(hi)
         self.statusBar.setSize(size)

--- a/Lib/trufont/windows/fontWindow.py
+++ b/Lib/trufont/windows/fontWindow.py
@@ -268,6 +268,7 @@ class FontWindow(BaseWindow):
         coordinatesSubmenu.fetchAction(Entries.View_Show_Coordinates_When_Selected)
         coordinatesSubmenu.fetchAction(Entries.View_Show_Point_Coordinates)
         coordinatesSubmenu.fetchAction(Entries.View_Show_Bezier_Handles_Coordinates)
+        viewMenu.fetchAction(Entries.View_Show_Curvatures)
         viewMenu.fetchAction(Entries.View_Show_Metrics)
         viewMenu.fetchAction(Entries.View_Show_Images)
         viewMenu.fetchAction(Entries.View_Show_Guidelines)

--- a/Lib/trufont/windows/metricsWindow.py
+++ b/Lib/trufont/windows/metricsWindow.py
@@ -585,7 +585,7 @@ class MetricsTable(QTableWidget):
         # let's use this one column to compute the width of others
         columnWidth = self.columnWidth(0)
         self._cellWidth = 0.5 * columnWidth
-        self.setColumnWidth(0, 0.55 * columnWidth)
+        self.setColumnWidth(0, int(0.55 * columnWidth))
         self.horizontalHeader().hide()
         self.verticalHeader().hide()
         self._coloredColumn = None
@@ -776,7 +776,7 @@ class MetricsTable(QTableWidget):
             kDisabled = not (index and self._kerningEnabled)
             # TODO: grey out cells when disabled
             self.setItem(4, index + 1, metricsTableItem(kValue, kDisabled))
-            self.setColumnWidth(index + 1, self._cellWidth)
+            self.setColumnWidth(index + 1, int(self._cellWidth))
             prevGlyph = glyph
 
     # ----------


### PR DESCRIPTION
Curvature visualization in type design is essential because it allows designers to see and adjust the flow and shape of letter forms intuitively. By visualizing the curvatures, designers can ensure smooth transitions and consistent stroke widths, leading to more aesthetically pleasing and readable typefaces. This feature enhances precision, enabling quick identification of areas that may need refinement, ultimately resulting in higher-quality font designs.

I am submitting an implementation that I have been using for the past year.
![overview](https://github.com/user-attachments/assets/8f11b71e-80d3-42dd-af64-5309f4a5accb)

The curvature is visualized on the convex side of the curves regardless of the direction for a consistent visualization.
The curvatures can be toggled with the `View > Show Curvatures` menu or by the shortcut `Ctrl+Shift+C`.

![curvature_menu_crop](https://github.com/user-attachments/assets/3d1906b6-5960-40fa-9ce5-8378f62173d7)

Because curvature is the reciprocal of the radius at a point on a curve, we need to scale the value to properly visualize it. A reasonable scale value for one curve may not be useful for another part. For example, for a rounded serif **s**, a useful scale value for the bend will be too big for the rounded serif.

To handle this we added an adjustment slider on the lower left corner of the status bar that is visible only when curvatures are shown. This slider can be used to adjust the scale of the curvature.

<img width="1920" alt="curvature_scale" src="https://github.com/user-attachments/assets/42d85915-ab89-48f3-bc5e-72e93d0240f1">

The curvature scale is proportionate to the ascender of the font. This keeps the scale relatively consistent for different fonts.

On a side note, I had to fix a few more places for the python 3.10 type hint issues with PyQT5. 

This was tested on Kubuntu 24.04, Win 11 (21H2), and macOS 10.15.7 (I am moving away from macs...).